### PR TITLE
Github->Biotools: Handle the case where homepage is the empty string

### DIFF
--- a/src/bridge/builders/github/github_transformer.py
+++ b/src/bridge/builders/github/github_transformer.py
@@ -35,6 +35,10 @@ class GitHubRepoTransformer(Transformer):
 
         repo_raw_data = raw_data.get("repo", {})
         latest_release_raw_data = raw_data.get("latest_release")
+
+        if not repo_raw_data["homepage"]:
+            repo_raw_data["homepage"] = None
+
         result = GitHubRepoModel(
             repo=FullRepository(**repo_raw_data),
             latest_release=Release(**latest_release_raw_data) if latest_release_raw_data else None,


### PR DESCRIPTION
## Summary
Empty string was failing url validation. Replace with a None to skip that validation.

## Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [x] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER