### PR TITLE
Output registration link

### DIFF
--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -3,7 +3,6 @@ Implements the GitHub→bio.tools metadata pipeline:
 derives a BiotoolsToolModel from a GitHubRepoModel.
 """
 
-import json
 import logging
 
 from bridge.core import BiotoolsToolModel, GitHubRepoModel
@@ -78,5 +77,5 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
-    logger.info(json.dumps(biotools_metadata))
-    return json.dumps(biotools_metadata)
+    logger.info(biotools_metadata.model_dump_json(indent=2))
+    return biotools_metadata.model_dump_json(indent=2)

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -3,6 +3,7 @@ Implements the GitHub→bio.tools metadata pipeline:
 derives a BiotoolsToolModel from a GitHubRepoModel.
 """
 
+import base64
 import logging
 import urllib
 
@@ -76,12 +77,15 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         homepage=mapper.map["homepage"].run(),
         license=github_repo.repo.license,
     )
+
+    biotools_url = "https://bio-tools-dev.sdu.dk"
+
     logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
     logger.info(
         f"\n\n*** 🛠  Want to create a bio.tools entry for this repo? ***\n"
-        f"🚀 (1) Log in to https://bio-tools-dev.sdu.dk\n"
-        f"✨ (2) click the following link:\n\nhttps://bio-tools-dev.sdu.dk/register"
-        f"?json={urllib.parse.quote(biotools_metadata.model_dump_json())} \n"
+        f"🚀 (1) Log in to {biotools_url}\n"
+        f"✨ (2) click the following link:\n\n{biotools_url}/register"
+        f"?json={urllib.parse.quote(base64.b64encode(biotools_metadata.model_dump_json().encode('ascii')))} \n"
     )
     return biotools_metadata

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -77,6 +77,9 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
     logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
+    logger.info("\n")
+    logger.info(f"Try clicking this link https://bio-tools-dev.sdu.dk/register?json={biotools_metadata} ")
     serialized = biotools_metadata
+    # serialized = json.dumps(biotools_metadata.model_dump_json())
     logger.info(serialized)
     return serialized

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -79,7 +79,9 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
     logger.info(
-        f"Try clicking this link https://bio-tools-dev.sdu.dk/register"
-        f"?json={urllib.parse.quote(biotools_metadata.model_dump_json())} "
+        f"\n*** Want to create a bio.tools entry for this repo? ***\n"
+        f"Log in to https://bio-tools-dev.sdu.dk, then "
+        f"clicking the following link:\n\nhttps://bio-tools-dev.sdu.dk/register"
+        f"?json={urllib.parse.quote(biotools_metadata.model_dump_json())} \n"
     )
     return biotools_metadata

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -77,5 +77,6 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
-    logger.info(biotools_metadata.model_dump_json(indent=2))
-    return biotools_metadata.model_dump_json(indent=2)
+    serialized = biotools_metadata.model_dump_json(indent=2)
+    logger.info(serialized)
+    return serialized

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -48,7 +48,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     logger.info(f"Running GitHub → bio.tools metadata pipeline for repo {args.repo_model.repo.name}")
 
     github_repo = args.repo_model
-
+    logger.info(1)
     # TODO: Implement actual logic to extract (or update) bio.tools metadata from github_repo
 
     # hf_provider = HuggingFaceProvider()
@@ -75,12 +75,10 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         name=github_repo.repo.name,
         description="pew pew pew pew pew pew",
         homepage=mapper.map["homepage"].run(),
-        license=github_repo.repo.license,
     )
 
     biotools_url = "https://bio-tools-dev.sdu.dk"
 
-    logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
     logger.info(
         f"\n\n*** 🛠  Want to create a bio.tools entry for this repo? ***\n"

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -79,9 +79,9 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
     logger.info(
-        f"\n*** Want to create a bio.tools entry for this repo? ***\n"
-        f"Log in to https://bio-tools-dev.sdu.dk, then "
-        f"clicking the following link:\n\nhttps://bio-tools-dev.sdu.dk/register"
+        f"\n\n*** 🛠  Want to create a bio.tools entry for this repo? ***\n"
+        f"🚀 (1) Log in to https://bio-tools-dev.sdu.dk\n"
+        f"✨ (2) click the following link:\n\nhttps://bio-tools-dev.sdu.dk/register"
         f"?json={urllib.parse.quote(biotools_metadata.model_dump_json())} \n"
     )
     return biotools_metadata

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -4,6 +4,7 @@ derives a BiotoolsToolModel from a GitHubRepoModel.
 """
 
 import logging
+import urllib
 
 from bridge.core import BiotoolsToolModel, GitHubRepoModel
 from bridge.pipelines.protocols import PipelineArgs
@@ -77,9 +78,8 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
     logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
-    logger.info("\n")
-    logger.info(f"Try clicking this link https://bio-tools-dev.sdu.dk/register?json={biotools_metadata} ")
-    serialized = biotools_metadata
-    # serialized = json.dumps(biotools_metadata.model_dump_json())
-    logger.info(serialized)
-    return serialized
+    logger.info(
+        f"Try clicking this link https://bio-tools-dev.sdu.dk/register"
+        f"?json={urllib.parse.quote(biotools_metadata.model_dump_json())} "
+    )
+    return biotools_metadata

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -48,7 +48,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     logger.info(f"Running GitHub → bio.tools metadata pipeline for repo {args.repo_model.repo.name}")
 
     github_repo = args.repo_model
-    logger.info(1)
+
     # TODO: Implement actual logic to extract (or update) bio.tools metadata from github_repo
 
     # hf_provider = HuggingFaceProvider()

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -77,6 +77,6 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
-    serialized = biotools_metadata.model_dump_json(indent=2)
+    serialized = biotools_metadata
     logger.info(serialized)
     return serialized

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -75,7 +75,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         homepage=mapper.map["homepage"].run(),
         license=github_repo.repo.license,
     )
-
+    logger.info(type(biotools_metadata))
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
     serialized = biotools_metadata
     logger.info(serialized)

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -3,6 +3,7 @@ Implements the GitHub→bio.tools metadata pipeline:
 derives a BiotoolsToolModel from a GitHubRepoModel.
 """
 
+import json
 import logging
 
 from bridge.core import BiotoolsToolModel, GitHubRepoModel
@@ -77,5 +78,5 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
-    logger.info(biotools_metadata)
-    return biotools_metadata
+    logger.info(json.dumps(biotools_metadata))
+    return json.dumps(biotools_metadata)

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -73,6 +73,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         name=github_repo.repo.name,
         description="pew pew pew pew pew pew",
         homepage=mapper.map["homepage"].run(),
+        license=github_repo.repo.license,
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -76,4 +76,5 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     )
 
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")
+    logger.info(biotools_metadata)
     return biotools_metadata


### PR DESCRIPTION
## Summary
When running `github-to-biotools extract`, output a link to automatically register a new biotools entry with this metadata

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [ ] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER