### PR TITLE
Feat/23 g b biotools license mapping

### DIFF
--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def map_license(gh_license: str, bt_license: str) -> str | None:
+def map_license(gh_license: str | None, bt_license: str | None) -> str | None:
     """
     Map GitHub license metadata to bio.tools license metadata.
 

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_license.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_license.py
@@ -1,0 +1,30 @@
+"""
+Unit tests for mapping function map GitHub license to bio.tools license
+"""
+
+import pytest
+
+from bridge.pipelines.gh2bt_for_meta.map_funcs.license import map_license
+
+
+@pytest.mark.parametrize(
+    "gh_license, bt_license, expected",
+    [
+        # Case 1: No GitHub license, bio.tools license exists
+        (None, "MIT", "MIT"),
+        # Case 2: No GitHub license, no bio.tools license
+        (None, None, None),
+        # Case 3: GitHub license exists, no bio.tools license
+        ("Apache-2.0", None, "Apache-2.0"),
+        # Case 4: Both licenses exist and match
+        ("GPL-3.0", "GPL-3.0", "GPL-3.0"),
+        # Case 5: Both licenses exist and conflict
+        ("BSD-3-Clause", "MIT", "BSD-3-Clause"),
+    ],
+)
+def test_map_license(gh_license, bt_license, expected):
+    """
+    Test map gh2bt license function.
+    """
+    result = map_license(gh_license, bt_license)
+    assert result == expected


### PR DESCRIPTION
## Summary
Allowed None as input for mapping license function and added unit test

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [ ] Rebased on latest `dev`
- [ ] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [ ] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER