### PR TITLE
Fix CFF, merge with existing if any

### DIFF
--- a/src/bridge/pipelines/bt2gh_for_pr/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map.py
@@ -5,7 +5,7 @@ Mapping classes for bio.tools to GitHub.
 from pydantic import BaseModel
 
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
-from bridge.pipelines.utils import get_file_content
+from bridge.pipelines.utils import load_dict_from_yaml_file
 
 from .map_funcs import map_citation, map_description, map_edam2topics, map_homepage, map_readme
 
@@ -63,7 +63,7 @@ class MapBioTools2GitHub(ModelsMap):
                     "topic": self.metadata.topic,
                     "description": self.metadata.description,
                 },
-                repo_entry=get_file_content(self.repo_path / "CITATION.cff"),
+                repo_entry=load_dict_from_yaml_file(self.repo_path / "CITATION.cff"),
                 method=Method.FUZZY,
                 fn=map_citation,
             ),

--- a/src/bridge/pipelines/bt2gh_for_pr/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map.py
@@ -5,7 +5,7 @@ Mapping classes for bio.tools to GitHub.
 from pydantic import BaseModel
 
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
-from bridge.pipelines.utils import check_file_with_extension_exists
+from bridge.pipelines.utils import get_file_content
 
 from .map_funcs import map_citation, map_description, map_edam2topics, map_homepage, map_readme
 
@@ -63,10 +63,7 @@ class MapBioTools2GitHub(ModelsMap):
                     "topic": self.metadata.topic,
                     "description": self.metadata.description,
                 },
-                repo_entry=check_file_with_extension_exists(
-                    in_folder_path=self.repo_path,
-                    file_extension=".cff",
-                ),
+                repo_entry=get_file_content(self.repo_path / "CITATION.cff"),
                 method=Method.FUZZY,
                 fn=map_citation,
             ),

--- a/src/bridge/pipelines/bt2gh_for_pr/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map.py
@@ -2,6 +2,8 @@
 Mapping classes for bio.tools to GitHub.
 """
 
+from pathlib import Path
+
 from pydantic import BaseModel
 
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
@@ -33,7 +35,7 @@ class MapBioTools2GitHub(ModelsMap):
 
     def __init__(self, repo, metadata, repo_path: str):
         super().__init__(repo=repo, metadata=metadata)
-        self.repo_path = repo_path
+        self.repo_path = Path(repo_path)
 
     @property
     def map(self) -> dict[str, MapItem]:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -16,7 +16,7 @@ import yaml
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import PublicationItem, TypeEnum2
-from bridge.pipelines.utils import object_to_primitive
+from bridge.pipelines.utils import normalize_dict_strings, normalize_pydantic_model_strings, object_to_primitive
 
 # TODO: add logging
 
@@ -58,17 +58,19 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
     topic = bt_params.get("topic", None)
     description = bt_params.get("description", None)
 
-    base_cff = {
-        "cff-version": "1.2.0",
-        "title": name or biotools_id,
-        "version": None,
-        "type": "software",
-        "repository": homepage,
-        "identifiers": [{"type": "other", "value": biotools_id, "description": "bio.tools"}],
-        "license": license,
-        "keywords": topic,
-        "abstract": description,
-    }
+    base_cff = normalize_dict_strings(
+        {
+            "cff-version": "1.2.0",
+            "title": name or biotools_id,
+            "version": None,
+            "type": "software",
+            "repository": homepage,
+            "identifiers": [{"type": "other", "value": biotools_id, "description": "bio.tools"}],
+            "license": license,
+            "keywords": topic,
+            "abstract": description,
+        }
+    )
 
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
@@ -132,7 +134,8 @@ async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) 
                 pmcid=primary_pub.pmcid,
                 doi=primary_pub.doi,
             )
-            references.append(epmc_publication)
+            empc_publication_norm = normalize_pydantic_model_strings(epmc_publication)
+            references.append(empc_publication_norm)
         except Exception as e:
             print(f"Warning: could not resolve {primary_pub}: {e}", file=sys.stderr)
 

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -16,6 +16,7 @@ import yaml
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import PublicationItem, TypeEnum2
+from bridge.pipelines.utils import to_primitive
 
 # TODO: add logging
 
@@ -82,7 +83,8 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
             }
         )
 
-    return {"CITATION.cff": yaml.dump(base_cff, sort_keys=False)}
+    primitive_cff = to_primitive(base_cff)
+    return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False)}
 
 
 async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) -> dict[str, str]:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -124,7 +124,7 @@ def _key_func(r):
     """
     if isinstance(r, Publication):
         return (r.year or 0, r.title or "")
-    return (r.get("year", 0) or 0, r.get("title", "") or "")
+    return (int(r.get("year", 0) or 0), r.get("title", "") or "")
 
 
 def _choose_preferred_citation(

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -124,7 +124,8 @@ async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) 
         If no primary publications could be resolved.
     """
     if gh_citation_cff_exists:
-        raise SystemExit("CITATION.cff already exists in the GitHub repository; skipping creation.")
+        logger.note("CITATION.cff already exists in the repository. Overwriting.")
+        # TODO: consider merging instead of overwriting
 
     bt_publication = bt_params.get("publication", None)
 

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -11,6 +11,8 @@ repository to enable software citation.
 from collections.abc import Hashable, Mapping
 from typing import Any
 
+import yaml
+
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import TypeEnum2
@@ -116,14 +118,9 @@ def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -
     return deduplicated
 
 
-def _compose_citation(
-    bt_params: dict[str, Any], references: list[Publication], primary_references: list[Publication]
-) -> dict[str, Any]:
+def _compose_base_cff(bt_params: dict[str, Any]) -> dict[str, Any]:
     """
-    Generate a CITATION.cff dict from bio.tools metadata and references.
-    If there are no references, a minimal CITATION.cff is created.
-    If there are primary references, most recent one of them is selected as preferred citation.
-    Otherwise, the most recent reference is selected.
+    Generate a base CITATION.cff dict from bio.tools metadata.
 
     Parameters
     ----------
@@ -136,15 +133,11 @@ def _compose_citation(
         - license - License of the tool.
         - topic - List of topics associated with the tool.
         - description - Description of the tool.
-    references : list[Publication]
-        List of all resolved Publication objects for the tool.
-    primary_references : list[Publication]
-        List of resolved Publication objects marked as Primary for the tool.
 
     Returns
     -------
     dict[str, Any]
-        A dictionary with the CITATION.cff content.
+        A dictionary with the CITATION.cff base content.
     """
     name = bt_params.get("name", None)
     biotools_id = bt_params.get("biotoolsID", None)
@@ -166,7 +159,34 @@ def _compose_citation(
             "abstract": description,
         }
     )
+    return base_cff
 
+
+def _compose_citation(
+    base_cff: dict[str, Any],
+    references: list[Publication | dict[str, Any]],
+    primary_references: list[Publication | dict[str, Any]],
+) -> dict[str, Any]:
+    """
+    Generate a CITATION.cff dict from bio.tools metadata and references.
+    If there are no references, a minimal CITATION.cff is created.
+    If there are primary references, most recent one of them is selected as preferred citation.
+    Otherwise, the most recent reference is selected.
+
+    Parameters
+    ----------
+    base_cff : dict[str, Any]
+        The base CITATION.cff content.
+    references : list[Publication | dict[str, Any]]
+        List of all publications to be included in CITATION.cff.
+    primary_references : list[Publication | dict[str, Any]]
+        List of publications marked as primary to be included in CITATION.cff.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary with the CITATION.cff content.
+    """
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
         logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
@@ -184,7 +204,6 @@ def _compose_citation(
 
     primitive_cff = object_to_primitive(base_cff)
     return primitive_cff
-    # return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
 
 
 async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any]) -> dict[str, str]:
@@ -217,14 +236,12 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     SystemExit
         If no primary publications could be resolved.
     """
-    if gh_citation_cff:
-        logger.note("CITATION.cff already exists in the repository. Merging.")
-        # TODO: consider merging instead of overwriting
-
     bt_publication = bt_params.get("publication", None)
 
-    references: list[Publication] = []
-    primary_references: list[Publication] = []
+    bt_references: list[Publication] = []
+    bt_primary_references: list[Publication] = []
+
+    gh_references: list[dict[str, Any]] = 1  # TODO using gh_citation_cff
 
     for pub in bt_publication or []:
         try:
@@ -234,12 +251,15 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
                 doi=pub.doi,
             )
             empc_publication_norm = normalize_pydantic_model_strings(epmc_publication)
-            references.append(empc_publication_norm)
+            bt_references.append(empc_publication_norm)
             if pub.type and TypeEnum2.Primary in pub.type:
-                primary_references.append(empc_publication_norm)
+                bt_primary_references.append(empc_publication_norm)
         except Exception as e:
             logger.note(f"Could not resolve publication {pub}: {e}")
 
-    cff = _compose_citation(bt_params=bt_params, references=references, primary_references=primary_references)
+    _deduplicate_references(bt_references + gh_references)
 
-    return cff
+    base_cff = _compose_base_cff(bt_params=bt_params)
+    cff = _compose_citation(base_cff=base_cff, references=bt_references, primary_references=bt_primary_references)
+
+    return {"CITATION.cff": yaml.dump(cff, sort_keys=False, allow_unicode=True)}

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -76,7 +76,7 @@ def _compose_citation(
 
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
-        logger.added("No publications found in bio.tools. Creating CITATION.cff without publications.")
+        logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
     else:
         selection_list_for_preferred = primary_references if primary_references else references
         preferred = max(selection_list_for_preferred, key=lambda r: (r.year or 0, r.title or ""))

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -8,24 +8,102 @@ The output is a valid `CITATION.cff` file that can be committed to a GitHub
 repository to enable software citation.
 """
 
+from collections.abc import Hashable
 from typing import Any
-
-import yaml
 
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import TypeEnum2
 from bridge.logging import get_user_logger
-from bridge.pipelines.utils import normalize_dict_strings, normalize_pydantic_model_strings, object_to_primitive
+from bridge.pipelines.utils import (
+    normalize_dict_strings,
+    normalize_pydantic_model_strings,
+    normalize_text,
+    object_to_primitive,
+)
 
 logger = get_user_logger()
 
 TIMEOUT = 20
 
 
+def _ref_key(ref: Publication) -> Hashable:
+    """
+    Extract all usable identifiers from a Publication as a normalized set.
+
+    Parameters
+    ----------
+    ref : Publication
+        The Publication object.
+
+    Returns
+    -------
+    set[str]
+        A set of normalized identifier strings.
+    """
+    ids: set[str] = set()
+
+    if ref.doi:
+        ids.add(f"doi:{normalize_text(ref.doi)}")
+
+    if ref.pmid:
+        ids.add(f"pmid:{ref.pmid}")
+
+    if ref.pmcid:
+        ids.add(f"pmcid:{ref.pmcid}")
+
+    if ref.title:
+        ids.add(f"title:{normalize_text(ref.title)}")
+
+    return ids
+
+
+def _deduplicate_references(references: list[Publication]) -> list[Publication]:
+    """
+    Deduplicate Publication objects: if ANY identifier overlaps, they are treated
+    as the same reference. First occurrence wins.
+
+    Parameters
+    ----------
+    references : list[Publication]
+        List of Publication objects to deduplicate.
+
+    Returns
+    -------
+    list[Publication]
+        Deduplicated list of Publication objects.
+    """
+    seen_identifier_sets: list[set[str]] = []
+    deduplicated: list[Publication] = []
+
+    for ref in references:
+        current_ids = _ref_key(ref)
+
+        # if we have no identifiers at all, treat as unique
+        if not current_ids:
+            deduplicated.append(ref)
+            continue
+
+        duplicate = False
+        for seen_ids in seen_identifier_sets:
+            if current_ids & seen_ids:  # intersection
+                duplicate = True
+                # merge identifier sets to strengthen future matching
+                seen_ids.update(current_ids)
+                break
+
+        if duplicate:
+            continue
+
+        seen_identifier_sets.append(set(current_ids))
+        deduplicated.append(ref)
+
+    return deduplicated
+
+
 def _compose_citation(
     bt_params: dict[str, Any], references: list[Publication], primary_references: list[Publication]
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """
     Generate a CITATION.cff dict from bio.tools metadata and references.
     If there are no references, a minimal CITATION.cff is created.
@@ -50,8 +128,8 @@ def _compose_citation(
 
     Returns
     -------
-    dict[str, str]
-        A dictionary with the filename as key and the CITATION.cff content as value.
+    dict[str, Any]
+        A dictionary with the CITATION.cff content.
     """
     name = bt_params.get("name", None)
     biotools_id = bt_params.get("biotoolsID", None)
@@ -90,7 +168,8 @@ def _compose_citation(
         logger.added(f"Added {len(references)} publication(s) to CITATION.cff.")
 
     primitive_cff = object_to_primitive(base_cff)
-    return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
+    return primitive_cff
+    # return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
 
 
 async def map_citation(gh_citation_cff: str | None, bt_params: dict[str, Any]) -> dict[str, str]:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -8,7 +8,7 @@ The output is a valid `CITATION.cff` file that can be committed to a GitHub
 repository to enable software citation.
 """
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 import yaml
@@ -29,7 +29,7 @@ logger = get_user_logger()
 TIMEOUT = 20
 
 
-def _ref_ids(ref: Publication | Mapping[str, Any]) -> Hashable:
+def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
     """
     Extract all usable identifiers from a Publication as a normalized set.
 
@@ -153,7 +153,7 @@ def _choose_preferred_citation(
     ----------
     references : list[Publication | dict[str, Any]]
         List of all publications.
-    bt_primary_references: list[Publication],
+    bt_primary_references: list[Publication]
         List of publications in bio.tools marked as primary.
     gh_preferred_reference : dict[str, Any] | None, optional
         The preferred citation from GitHub CITATION.cff, if any.
@@ -255,7 +255,12 @@ def _extract_gh_references(
         if not in_refs:
             gh_references.append(gh_preferred)
 
-    logger.note(f"CITATION.cff is not empty. Found {len(gh_references)} reference(s) to merge with bio.tools metadata.")
+    if gh_references:
+        logger.note(
+            f"CITATION.cff is not empty. Found {len(gh_references)} reference(s) to merge with bio.tools metadata."
+        )
+    else:
+        logger.note("CITATION.cff exists but contains no references. Using only bio.tools metadata.")
 
     return gh_references, gh_preferred
 
@@ -285,7 +290,9 @@ def _compose_citation(
     """
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
-        logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
+        logger.added(
+            "No publications found in bio.tools or existing CITATION.cff. Creating CITATION.cff with minimal metadata."
+        )
     else:
         update_data = {
             "message": ("If you use this software, please cite it and the Primary publications below."),
@@ -324,11 +331,6 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     -------
     dict[str, str]
         A dictionary with the filename as key and the CITATION.cff content as value.
-
-    Raises
-    ------
-    SystemExit
-        If no primary publications could be resolved.
     """
     bt_publication = bt_params.get("publication", None)
 
@@ -351,9 +353,9 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
         except Exception as e:
             logger.note(f"Could not resolve publication {pub}: {e}")
 
-    references = _deduplicate_references(bt_references + gh_references)
+    references = _deduplicate_references(gh_references + bt_references)
 
-    preferred_reference = _choose_preferred_citation(  # TODO: update this function
+    preferred_reference = _choose_preferred_citation(
         references=references,
         bt_primary_references=bt_primary_references,
         gh_preferred_reference=gh_preferred,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -118,9 +118,19 @@ def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -
     return deduplicated
 
 
-def _key_func(r):
+def _key_func(r: Publication | dict[str, Any]) -> tuple[int, str]:
     """
     Key function to select the most recent publication based on year and title.
+
+    Parameters
+    ----------
+    r : Publication | dict[str, Any]
+        The publication to evaluate.
+
+    Returns
+    -------
+    tuple[int, str]
+        A tuple containing the year (as int) and title (as str) for comparison.
     """
     if isinstance(r, Publication):
         return (r.year or 0, r.title or "")
@@ -131,7 +141,7 @@ def _choose_preferred_citation(
     references: list[Publication | dict[str, Any]],
     bt_primary_references: list[Publication],
     gh_preferred_reference: dict[str, Any] | None = None,
-) -> Publication | dict[str, Any]:
+) -> Publication | dict[str, Any] | None:
     """
     Choose the preferred citation from the list of references.
     If there is a preferred citation from the existing GitHub CITATION.cff file, it is used.
@@ -150,12 +160,14 @@ def _choose_preferred_citation(
 
     Returns
     -------
-    Publication | dict[str, Any]
-        The selected preferred citation.
+    Publication | dict[str, Any] | None
+        The selected preferred citation, or None if no references are available.
     """
     if gh_preferred_reference is not None:
         return gh_preferred_reference
     selection_list = bt_primary_references if bt_primary_references else references
+    if not selection_list:
+        return None
     preferred = max(selection_list, key=_key_func)
     return preferred
 
@@ -242,6 +254,8 @@ def _extract_gh_references(
         in_refs = any(_ref_ids(r) & pref_ids for r in gh_references)
         if not in_refs:
             gh_references.append(gh_preferred)
+
+    logger.note(f"CITATION.cff is not empty. Found {len(gh_references)} reference(s) to merge with bio.tools metadata.")
 
     return gh_references, gh_preferred
 

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -129,24 +129,33 @@ def _key_func(r):
 
 def _choose_preferred_citation(
     references: list[Publication | dict[str, Any]],
-    primary_references: list[Publication | dict[str, Any]],
+    bt_primary_references: list[Publication],
+    gh_preferred_reference: dict[str, Any] | None = None,
 ) -> Publication | dict[str, Any]:
     """
     Choose the preferred citation from the list of references.
+    If there is a preferred citation from the existing GitHub CITATION.cff file, it is used.
+    If not, but there are primary references in bio.tools, the most recent one is selected as the preferred citation.
+    Otherwise, the most recent reference of any other type is chosen.
+
 
     Parameters
     ----------
     references : list[Publication | dict[str, Any]]
         List of all publications.
-    primary_references : list[Publication | dict[str, Any]]
-        List of publications marked as primary.
+    bt_primary_references: list[Publication],
+        List of publications in bio.tools marked as primary.
+    gh_preferred_reference : dict[str, Any] | None, optional
+        The preferred citation from GitHub CITATION.cff, if any.
 
     Returns
     -------
     Publication | dict[str, Any]
         The selected preferred citation.
     """
-    selection_list = primary_references if primary_references else references
+    if gh_preferred_reference is not None:
+        return gh_preferred_reference
+    selection_list = bt_primary_references if bt_primary_references else references
     preferred = max(selection_list, key=_key_func)
     return preferred
 
@@ -245,8 +254,6 @@ def _compose_citation(
     """
     Generate a CITATION.cff dict from bio.tools metadata and references.
     If there are no references, a minimal CITATION.cff is created.
-    If there are primary references, most recent one of them is selected as preferred citation.
-    Otherwise, the most recent reference is selected.
 
     Parameters
     ----------
@@ -333,7 +340,8 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
 
     preferred_reference = _choose_preferred_citation(  # TODO: update this function
         references=references,
-        primary_references=bt_primary_references,
+        bt_primary_references=bt_primary_references,
+        gh_preferred_reference=gh_preferred,
     )
 
     base_cff = _compose_base_cff(bt_params=bt_params)

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -187,23 +187,28 @@ def _compose_citation(
     dict[str, Any]
         A dictionary with the CITATION.cff content.
     """
+
+    def key_func(r):
+        if isinstance(r, Publication):
+            return (r.year or 0, r.title or "")
+        return (r.get("year", 0) or 0, r.get("title", "") or "")
+
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
         logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
     else:
         selection_list_for_preferred = primary_references if primary_references else references
-        preferred = max(selection_list_for_preferred, key=lambda r: (r.year or 0, r.title or ""))
+        preferred = max(selection_list_for_preferred, key=key_func)
         base_cff.update(
             {
                 "message": ("If you use this software, please cite it and the Primary publications below."),
-                "preferred-citation": preferred,
-                "references": references,
+                "preferred-citation": object_to_primitive(preferred),
+                "references": object_to_primitive(references),
             }
         )
         logger.added(f"Added {len(references)} publication(s) to CITATION.cff.")
 
-    primitive_cff = object_to_primitive(base_cff)
-    return primitive_cff
+    return base_cff
 
 
 async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any]) -> dict[str, str]:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -8,7 +8,7 @@ The output is a valid `CITATION.cff` file that can be committed to a GitHub
 repository to enable software citation.
 """
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping
 from typing import Any
 
 from bridge.builders import compose_europe_pmc_metadata
@@ -27,54 +27,69 @@ logger = get_user_logger()
 TIMEOUT = 20
 
 
-def _ref_key(ref: Publication) -> Hashable:
+def _ref_key(ref: Publication | Mapping[str, Any]) -> Hashable:
     """
     Extract all usable identifiers from a Publication as a normalized set.
 
     Parameters
     ----------
-    ref : Publication
-        The Publication object.
+    ref : Publication | Mapping[str, Any]
+        The Publication object or dictionary representing a publication.
 
     Returns
     -------
     set[str]
         A set of normalized identifier strings.
+
+    Raises
+    ------
+    TypeError
+        If ref is neither a Publication nor a Mapping.
     """
+    if isinstance(ref, Mapping):
+        doi = ref.get("doi", None)
+        pmid = ref.get("pmid", None)
+        pmcid = ref.get("pmcid", None)
+        title = ref.get("title", None)
+    elif isinstance(ref, Publication):
+        doi = getattr(ref, "doi", None)
+        pmid = getattr(ref, "pmid", None)
+        pmcid = getattr(ref, "pmcid", None)
+        title = getattr(ref, "title", None)
+    else:
+        raise TypeError("ref must be a Publication or a Mapping")
+
     ids: set[str] = set()
 
-    if ref.doi:
-        ids.add(f"doi:{normalize_text(ref.doi)}")
-
-    if ref.pmid:
-        ids.add(f"pmid:{ref.pmid}")
-
-    if ref.pmcid:
-        ids.add(f"pmcid:{ref.pmcid}")
-
-    if ref.title:
-        ids.add(f"title:{normalize_text(ref.title)}")
+    if doi:
+        ids.add(f"doi:{normalize_text(str(doi))}")
+    if pmid:
+        ids.add(f"pmid:{str(pmid).strip()}")
+    if pmcid:
+        ids.add(f"pmcid:{str(pmcid).strip()}")
+    if title:
+        ids.add(f"title:{normalize_text(str(title))}")
 
     return ids
 
 
-def _deduplicate_references(references: list[Publication]) -> list[Publication]:
+def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -> list[Publication | Mapping[str, Any]]:
     """
     Deduplicate Publication objects: if ANY identifier overlaps, they are treated
     as the same reference. First occurrence wins.
 
     Parameters
     ----------
-    references : list[Publication]
-        List of Publication objects to deduplicate.
+    references : list[Publication | Mapping[str, Any]]
+        List of references to deduplicate.
 
     Returns
     -------
-    list[Publication]
-        Deduplicated list of Publication objects.
+    list[Publication | Mapping[str, Any]]
+        Deduplicated list of references.
     """
     seen_identifier_sets: list[set[str]] = []
-    deduplicated: list[Publication] = []
+    deduplicated: list[Publication | Mapping[str, Any]] = []
 
     for ref in references:
         current_ids = _ref_key(ref)

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -8,49 +8,51 @@ The output is a valid `CITATION.cff` file that can be committed to a GitHub
 repository to enable software citation.
 """
 
-import sys
 from typing import Any
 
 import yaml
 
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
-from bridge.core.biotools import PublicationItem, TypeEnum2
+from bridge.core.biotools import TypeEnum2
+from bridge.logging import get_user_logger
 from bridge.pipelines.utils import normalize_dict_strings, normalize_pydantic_model_strings, object_to_primitive
 
-# TODO: add logging
+logger = get_user_logger()
 
 TIMEOUT = 20
 
 
-def _require_primary_publications(bt_publication: list[PublicationItem] | None) -> list[PublicationItem]:
+def _compose_citation(
+    bt_params: dict[str, Any], references: list[Publication], primary_references: list[Publication]
+) -> dict[str, str]:
     """
-    Return the PublicationItem marked as Primary, if exists.
+    Generate a CITATION.cff dict from bio.tools metadata and references.
+    If there are no references, a minimal CITATION.cff is created.
+    If there are primary references, most recent one of them is selected as preferred citation.
+    Otherwise, the most recent reference is selected.
 
     Parameters
     ----------
-    meta : BiotoolsToolModel
-        The bio.tools tool metadata model.
+    bt_params : dict[str, Any]
+        The bio.tools tool relevant metadata as a dictionary.
+        Should contain:
+        - name - Name of the tool.
+        - biotoolsID - bio.tools identifier of the tool.
+        - homepage - Homepage URL of the tool.
+        - license - License of the tool.
+        - topic - List of topics associated with the tool.
+        - description - Description of the tool.
+    references : list[Publication]
+        List of all resolved Publication objects for the tool.
+    primary_references : list[Publication]
+        List of resolved Publication objects marked as Primary for the tool.
 
     Returns
     -------
-    PublicationItem
-        The PublicationItem marked as Primary.
-
-    Raises
-    ------
-    LookupError
-        If no Primary publication is found in the provided metadata.
+    dict[str, str]
+        A dictionary with the filename as key and the CITATION.cff content as value.
     """
-    pubs = bt_publication or []
-    primary = [p for p in pubs if p.type and TypeEnum2.Primary in p.type]
-    if not primary:
-        raise LookupError("No primary publication found in ToolModel.publication.")
-    return primary
-
-
-def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
-    """Generate a CITATION.cff dict from bio.tools metadata and references."""
     name = bt_params.get("name", None)
     biotools_id = bt_params.get("biotoolsID", None)
     homepage = bt_params.get("homepage", None)
@@ -74,9 +76,10 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
 
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
-        print("Resolved 0 Primary publications; creating CITATION.cff without publications.")
+        logger.added("No publications found in bio.tools. Creating CITATION.cff without publications.")
     else:
-        preferred = max(references, key=lambda r: (r.year or 0, r.title or ""))
+        selection_list_for_preferred = primary_references if primary_references else references
+        preferred = max(selection_list_for_preferred, key=lambda r: (r.year or 0, r.title or ""))
         base_cff.update(
             {
                 "message": ("If you use this software, please cite it and the Primary publications below."),
@@ -84,6 +87,7 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
                 "references": references,
             }
         )
+        logger.added(f"Added {len(references)} publication(s) to CITATION.cff.")
 
     primitive_cff = object_to_primitive(base_cff)
     return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
@@ -91,7 +95,7 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
 
 async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) -> dict[str, str]:
     """
-    Generate CITATION.cff content from the primary publications of a bio.tools tool.
+    Generate CITATION.cff content from the publications of a bio.tools tool.
     It uses Europe PMC to resolve publication metadata.
 
     Parameters
@@ -124,21 +128,23 @@ async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) 
 
     bt_publication = bt_params.get("publication", None)
 
-    primary_publications = _require_primary_publications(bt_publication)
     references: list[Publication] = []
+    primary_references: list[Publication] = []
 
-    for primary_pub in primary_publications:
+    for pub in bt_publication or []:
         try:
             epmc_publication = await compose_europe_pmc_metadata(
-                pmid=primary_pub.pmid,
-                pmcid=primary_pub.pmcid,
-                doi=primary_pub.doi,
+                pmid=pub.pmid,
+                pmcid=pub.pmcid,
+                doi=pub.doi,
             )
             empc_publication_norm = normalize_pydantic_model_strings(epmc_publication)
             references.append(empc_publication_norm)
+            if pub.type and TypeEnum2.Primary in pub.type:
+                primary_references.append(empc_publication_norm)
         except Exception as e:
-            print(f"Warning: could not resolve {primary_pub}: {e}", file=sys.stderr)
+            logger.note(f"Could not resolve publication {pub}: {e}")
 
-    cff = _compose_citation(bt_params=bt_params, references=references)
+    cff = _compose_citation(bt_params=bt_params, references=references, primary_references=primary_references)
 
     return cff

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -86,7 +86,7 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
         )
 
     primitive_cff = object_to_primitive(base_cff)
-    return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False)}
+    return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
 
 
 async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) -> dict[str, str]:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -93,15 +93,15 @@ def _compose_citation(
     return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
 
 
-async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) -> dict[str, str]:
+async def map_citation(gh_citation_cff: str | None, bt_params: dict[str, Any]) -> dict[str, str]:
     """
     Generate CITATION.cff content from the publications of a bio.tools tool.
     It uses Europe PMC to resolve publication metadata.
 
     Parameters
     ----------
-    gh_citation_cff_exists : bool
-        Whether a CITATION.cff file already exists in the GitHub repository.
+    gh_citation_cff : str | None
+        The content of an existing CITATION.cff file in the GitHub repository or None if it does not exist.
     bt_params : dict[str, Any]
         The bio.tools tool relevant metadata as a dictionary.
         Should contain:
@@ -123,8 +123,8 @@ async def map_citation(gh_citation_cff_exists: bool, bt_params: dict[str, Any]) 
     SystemExit
         If no primary publications could be resolved.
     """
-    if gh_citation_cff_exists:
-        logger.note("CITATION.cff already exists in the repository. Overwriting.")
+    if gh_citation_cff:
+        logger.note("CITATION.cff already exists in the repository. Merging.")
         # TODO: consider merging instead of overwriting
 
     bt_publication = bt_params.get("publication", None)

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -29,7 +29,7 @@ logger = get_user_logger()
 TIMEOUT = 20
 
 
-def _ref_key(ref: Publication | Mapping[str, Any]) -> Hashable:
+def _ref_ids(ref: Publication | Mapping[str, Any]) -> Hashable:
     """
     Extract all usable identifiers from a Publication as a normalized set.
 
@@ -94,7 +94,7 @@ def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -
     deduplicated: list[Publication | Mapping[str, Any]] = []
 
     for ref in references:
-        current_ids = _ref_key(ref)
+        current_ids = _ref_ids(ref)
 
         # if we have no identifiers at all, treat as unique
         if not current_ids:
@@ -116,6 +116,39 @@ def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -
         deduplicated.append(ref)
 
     return deduplicated
+
+
+def _key_func(r):
+    """
+    Key function to select the most recent publication based on year and title.
+    """
+    if isinstance(r, Publication):
+        return (r.year or 0, r.title or "")
+    return (r.get("year", 0) or 0, r.get("title", "") or "")
+
+
+def _choose_preferred_citation(
+    references: list[Publication | dict[str, Any]],
+    primary_references: list[Publication | dict[str, Any]],
+) -> Publication | dict[str, Any]:
+    """
+    Choose the preferred citation from the list of references.
+
+    Parameters
+    ----------
+    references : list[Publication | dict[str, Any]]
+        List of all publications.
+    primary_references : list[Publication | dict[str, Any]]
+        List of publications marked as primary.
+
+    Returns
+    -------
+    Publication | dict[str, Any]
+        The selected preferred citation.
+    """
+    selection_list = primary_references if primary_references else references
+    preferred = max(selection_list, key=_key_func)
+    return preferred
 
 
 def _compose_base_cff(bt_params: dict[str, Any]) -> dict[str, Any]:
@@ -162,10 +195,52 @@ def _compose_base_cff(bt_params: dict[str, Any]) -> dict[str, Any]:
     return base_cff
 
 
+def _extract_gh_references(
+    gh_citation_cff: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """
+    Extract references and preferred-citation from an existing CITATION.cff dict.
+
+    Parameters
+    ----------
+    gh_citation_cff : dict[str, Any] | None
+        The existing CITATION.cff content from the GitHub repository.
+
+    Returns
+    -------
+    tuple[list[dict[str, Any]], dict[str, Any] | None]
+        A tuple containing:
+        - A list of references extracted from the CITATION.cff.
+        - The preferred-citation extracted from the CITATION.cff, or None if not present
+    """
+    if not gh_citation_cff:
+        return [], None
+
+    gh_citation_cff = normalize_dict_strings(gh_citation_cff)
+
+    gh_references = gh_citation_cff.get("references") or []
+    gh_references = [r for r in gh_references if isinstance(r, Mapping)]
+
+    gh_preferred = gh_citation_cff.get("preferred-citation")
+    if isinstance(gh_preferred, Mapping):
+        gh_preferred = dict(gh_preferred)  # shallow copy
+    else:
+        gh_preferred = None
+
+    # ensure preferred-citation is included in references if present
+    if gh_preferred is not None:
+        pref_ids = _ref_ids(gh_preferred)
+        in_refs = any(_ref_ids(r) & pref_ids for r in gh_references)
+        if not in_refs:
+            gh_references.append(gh_preferred)
+
+    return gh_references, gh_preferred
+
+
 def _compose_citation(
     base_cff: dict[str, Any],
     references: list[Publication | dict[str, Any]],
-    primary_references: list[Publication | dict[str, Any]],
+    preferred: Publication | dict[str, Any],
 ) -> dict[str, Any]:
     """
     Generate a CITATION.cff dict from bio.tools metadata and references.
@@ -179,26 +254,18 @@ def _compose_citation(
         The base CITATION.cff content.
     references : list[Publication | dict[str, Any]]
         List of all publications to be included in CITATION.cff.
-    primary_references : list[Publication | dict[str, Any]]
-        List of publications marked as primary to be included in CITATION.cff.
+    preferred : Publication | dict[str, Any]
+        The selected preferred citation to be included in CITATION.cff.
 
     Returns
     -------
     dict[str, Any]
         A dictionary with the CITATION.cff content.
     """
-
-    def key_func(r):
-        if isinstance(r, Publication):
-            return (r.year or 0, r.title or "")
-        return (r.get("year", 0) or 0, r.get("title", "") or "")
-
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
         logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
     else:
-        selection_list_for_preferred = primary_references if primary_references else references
-        preferred = max(selection_list_for_preferred, key=key_func)
         base_cff.update(
             {
                 "message": ("If you use this software, please cite it and the Primary publications below."),
@@ -246,7 +313,7 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     bt_references: list[Publication] = []
     bt_primary_references: list[Publication] = []
 
-    gh_references: list[dict[str, Any]] = 1  # TODO using gh_citation_cff
+    gh_references, gh_preferred = _extract_gh_references(gh_citation_cff)
 
     for pub in bt_publication or []:
         try:
@@ -262,9 +329,14 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
         except Exception as e:
             logger.note(f"Could not resolve publication {pub}: {e}")
 
-    _deduplicate_references(bt_references + gh_references)
+    references = _deduplicate_references(bt_references + gh_references)
+
+    preferred_reference = _choose_preferred_citation(  # TODO: update this function
+        references=references,
+        primary_references=bt_primary_references,
+    )
 
     base_cff = _compose_base_cff(bt_params=bt_params)
-    cff = _compose_citation(base_cff=base_cff, references=bt_references, primary_references=bt_primary_references)
+    cff = _compose_citation(base_cff=base_cff, references=references, preferred=preferred_reference)
 
     return {"CITATION.cff": yaml.dump(cff, sort_keys=False, allow_unicode=True)}

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -399,10 +399,10 @@ def _compose_citation(
     else:
         update_data = {
             "message": ("If you use this software, please cite it and the Primary publications below."),
-            "references": object_to_primitive(references),
+            "references": references,
         }
         if preferred is not None:
-            update_data["preferred-citation"] = object_to_primitive(preferred)
+            update_data["preferred-citation"] = preferred
 
         base_cff.update(normalize_dict_strings(update_data))
         logger.added(f"Added {len(references)} publication(s) to CITATION.cff.")
@@ -481,5 +481,6 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     base_cff = _compose_base_cff(bt_params=bt_params)
     base_cff = _merge_top_level_metadata(existing_cff=gh_citation_cff, base_cff=base_cff)
     cff = _compose_citation(base_cff=base_cff, references=references, preferred=preferred_reference)
+    primitive_cff = object_to_primitive(cff)
 
-    return {"CITATION.cff": yaml.dump(cff, sort_keys=False, allow_unicode=True)}
+    return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -1,8 +1,8 @@
 """
 Generate a CITATION.cff file from bio.tools publication metadata.
 
-This module retrieves metadata for a given bio.tools entry, identifies its
-Primary publications, resolves them via the Europe PMC REST API, and converts
+This module retrieves publications from a bio.tools entry,
+resolves them via the Europe PMC REST API, and converts
 the resulting bibliographic information into the Citation File Format (CFF).
 The output is a valid `CITATION.cff` file that can be committed to a GitHub
 repository to enable software citation.

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -249,7 +249,7 @@ def _extract_gh_references(
 def _compose_citation(
     base_cff: dict[str, Any],
     references: list[Publication | dict[str, Any]],
-    preferred: Publication | dict[str, Any],
+    preferred: Publication | dict[str, Any] | None,
 ) -> dict[str, Any]:
     """
     Generate a CITATION.cff dict from bio.tools metadata and references.
@@ -261,8 +261,8 @@ def _compose_citation(
         The base CITATION.cff content.
     references : list[Publication | dict[str, Any]]
         List of all publications to be included in CITATION.cff.
-    preferred : Publication | dict[str, Any]
-        The selected preferred citation to be included in CITATION.cff.
+    preferred : Publication | dict[str, Any] | None
+        The selected preferred citation to be included in CITATION.cff, if any.
 
     Returns
     -------
@@ -273,13 +273,14 @@ def _compose_citation(
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
         logger.added("No publications found in bio.tools. Creating CITATION.cff with minimal metadata.")
     else:
-        base_cff.update(
-            {
-                "message": ("If you use this software, please cite it and the Primary publications below."),
-                "preferred-citation": object_to_primitive(preferred),
-                "references": object_to_primitive(references),
-            }
-        )
+        update_data = {
+            "message": ("If you use this software, please cite it and the Primary publications below."),
+            "references": object_to_primitive(references),
+        }
+        if preferred is not None:
+            update_data["preferred-citation"] = object_to_primitive(preferred)
+
+        base_cff.update(normalize_dict_strings(update_data))
         logger.added(f"Added {len(references)} publication(s) to CITATION.cff.")
 
     return base_cff

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -26,8 +26,6 @@ from bridge.pipelines.utils import (
 
 logger = get_user_logger()
 
-TIMEOUT = 20
-
 
 def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
     """
@@ -148,7 +146,6 @@ def _choose_preferred_citation(
     If not, but there are primary references in bio.tools, the most recent one is selected as the preferred citation.
     Otherwise, the most recent reference of any other type is chosen.
 
-
     Parameters
     ----------
     references : list[Publication | dict[str, Any]]
@@ -214,6 +211,54 @@ def _compose_base_cff(bt_params: dict[str, Any]) -> dict[str, Any]:
         }
     )
     return base_cff
+
+
+def _merge_top_level_metadata(
+    existing_cff: dict[str, Any] | None,
+    base_cff: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Merge top-level CFF metadata.
+
+    Policy:
+    - If no existing CITATION.cff, return base_cff as is.
+    - Otherwise, start from existing CITATION.cff.
+    - For known top-level keys we manage:
+      - If existing has a non-empty value, keep it.
+      - If existing is missing/empty, fill from base_cff.
+    - Never touch 'references' or 'preferred-citation' here; they are handled separately.
+
+    Parameters
+    ----------
+    existing_cff : dict[str, Any] | None
+        The existing CITATION.cff content from the GitHub repository.
+    base_cff : dict[str, Any]
+        The base CITATION.cff content generated from bio.tools metadata.
+
+    Returns
+    -------
+    dict[str, Any]
+        The merged CITATION.cff content.
+    """
+    if existing_cff is None:
+        return base_cff
+
+    merged = dict(existing_cff)
+
+    # handle preferred and references separately
+    merged.pop("references", None)
+    merged.pop("preferred-citation", None)
+
+    # add bio.tools metadata where missing
+    for key, val in base_cff.items():
+        if val is None:
+            continue
+
+        existing_val = merged.get(key, None)
+        if existing_val in (None, "", []):
+            merged[key] = val
+
+    return merged
 
 
 def _extract_gh_references(
@@ -362,6 +407,7 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     )
 
     base_cff = _compose_base_cff(bt_params=bt_params)
+    base_cff = _merge_top_level_metadata(existing_cff=gh_citation_cff, base_cff=base_cff)
     cff = _compose_citation(base_cff=base_cff, references=references, preferred=preferred_reference)
 
     return {"CITATION.cff": yaml.dump(cff, sort_keys=False, allow_unicode=True)}

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -187,15 +187,15 @@ def _compose_citation(
     # return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False, allow_unicode=True)}
 
 
-async def map_citation(gh_citation_cff: str | None, bt_params: dict[str, Any]) -> dict[str, str]:
+async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any]) -> dict[str, str]:
     """
     Generate CITATION.cff content from the publications of a bio.tools tool.
     It uses Europe PMC to resolve publication metadata.
 
     Parameters
     ----------
-    gh_citation_cff : str | None
-        The content of an existing CITATION.cff file in the GitHub repository or None if it does not exist.
+    gh_citation_cff : dict[str, Any]
+        The existing CITATION.cff content from the GitHub repository.
     bt_params : dict[str, Any]
         The bio.tools tool relevant metadata as a dictionary.
         Should contain:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -1,11 +1,16 @@
 """
 Generate a CITATION.cff file from bio.tools publication metadata.
 
-This module retrieves publications from a bio.tools entry,
-resolves them via the Europe PMC REST API, and converts
-the resulting bibliographic information into the Citation File Format (CFF).
-The output is a valid `CITATION.cff` file that can be committed to a GitHub
-repository to enable software citation.
+This module retrieves publications from a bio.tools entry, resolves them via the
+Europe PMC REST API, and converts the resulting bibliographic information into
+the Citation File Format (CFF).
+
+If a CITATION.cff already exists in the GitHub repository, its non-publication
+metadata is preserved where present, and its publication list is merged with
+publications discovered via bio.tools / Europe PMC. References are
+deduplicated, and a preferred citation is chosen with a clear precedence:
+existing preferred-citation (if any) > bio.tools primary publications > other
+publications.
 """
 
 from collections.abc import Mapping
@@ -29,7 +34,15 @@ logger = get_user_logger()
 
 def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
     """
-    Extract all usable identifiers from a Publication as a normalized set.
+    Extract a normalized set of identifiers for a publication-like object.
+    This function collects all available identifiers and returns
+    them as normalized strings, which can then be used for deduplication.
+
+    Normalized identifiers include (when present):
+    - DOI
+    - PMID
+    - PMCID
+    - title
 
     Parameters
     ----------
@@ -40,11 +53,12 @@ def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
     -------
     set[str]
         A set of normalized identifier strings.
+        The set may be empty if no identifiers are present.
 
     Raises
     ------
     TypeError
-        If ref is neither a Publication nor a Mapping.
+        If `ref` is neither a `Publication` instance nor a mapping.
     """
     if isinstance(ref, Mapping):
         doi = ref.get("doi", None)
@@ -75,18 +89,22 @@ def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
 
 def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -> list[Publication | Mapping[str, Any]]:
     """
-    Deduplicate Publication objects: if ANY identifier overlaps, they are treated
-    as the same reference. First occurrence wins.
+    Deduplicate a list of publication-like objects based on shared identifiers.
+
+    Two references are considered duplicates if they share at least one
+    normalized identifier (DOI, PMID, PMCID, or title). The first occurrence
+    in the input list is retained; all later duplicates are dropped.
 
     Parameters
     ----------
     references : list[Publication | Mapping[str, Any]]
-        List of references to deduplicate.
+        List of references (models or dicts) to deduplicate.
 
     Returns
     -------
     list[Publication | Mapping[str, Any]]
-        Deduplicated list of references.
+        Deduplicated list of references, preserving original order for
+        the first occurrence of each logical publication.
     """
     seen_identifier_sets: list[set[str]] = []
     deduplicated: list[Publication | Mapping[str, Any]] = []
@@ -118,17 +136,23 @@ def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -
 
 def _key_func(r: Publication | dict[str, Any]) -> tuple[int, str]:
     """
-    Key function to select the most recent publication based on year and title.
+    Key function for ordering publications by recency and title.
+
+    Publications are ordered primarily by year (descending when used with `max`)
+    and secondarily by title (lexicographically). This is used to select a
+    "most recent" publication when choosing a preferred citation.
 
     Parameters
     ----------
     r : Publication | dict[str, Any]
-        The publication to evaluate.
+        The publication to evaluate, as either a `Publication` instance or a
+        reference dictionary.
 
     Returns
     -------
     tuple[int, str]
-        A tuple containing the year (as int) and title (as str) for comparison.
+        A tuple `(year, title)` suitable for use as a sort key.
+        Missing years are treated as 0; missing titles as an empty string.
     """
     if isinstance(r, Publication):
         return (r.year or 0, r.title or "")
@@ -141,24 +165,30 @@ def _choose_preferred_citation(
     gh_preferred_reference: dict[str, Any] | None = None,
 ) -> Publication | dict[str, Any] | None:
     """
-    Choose the preferred citation from the list of references.
-    If there is a preferred citation from the existing GitHub CITATION.cff file, it is used.
-    If not, but there are primary references in bio.tools, the most recent one is selected as the preferred citation.
-    Otherwise, the most recent reference of any other type is chosen.
+    Select the preferred citation among all available references.
+
+    Precedence rules:
+    1. If the existing GitHub CITATION.cff contains a `preferred-citation`,
+       it is preserved and returned unchanged.
+    2. Otherwise, if there are primary publications in the bio.tools metadata,
+       the most recent primary publication is selected.
+    3. Otherwise, the most recent publication from the full reference list
+       is selected.
+    4. If no references are available, returns ``None``.
 
     Parameters
     ----------
     references : list[Publication | dict[str, Any]]
-        List of all publications.
+        List of all resolved references.
     bt_primary_references: list[Publication]
-        List of publications in bio.tools marked as primary.
+        List (subset) of bio.tools publications that are marked as primary.
     gh_preferred_reference : dict[str, Any] | None, optional
-        The preferred citation from GitHub CITATION.cff, if any.
+        Existing `preferred-citation` from a CITATION.cff file, if any.
 
     Returns
     -------
     Publication | dict[str, Any] | None
-        The selected preferred citation, or None if no references are available.
+        The selected preferred citation, or ``None`` if no references exist.
     """
     if gh_preferred_reference is not None:
         return gh_preferred_reference
@@ -171,24 +201,29 @@ def _choose_preferred_citation(
 
 def _compose_base_cff(bt_params: dict[str, Any]) -> dict[str, Any]:
     """
-    Generate a base CITATION.cff dict from bio.tools metadata.
+    Build a base CITATION.cff structure from bio.tools tool metadata.
+
+    This function creates a minimal, publication-agnostic CFF dictionary based
+    on the fields exposed in the bio.tools API. It does not include any
+    references or preferred-citation; those are added later.
 
     Parameters
     ----------
     bt_params : dict[str, Any]
-        The bio.tools tool relevant metadata as a dictionary.
-        Should contain:
-        - name - Name of the tool.
-        - biotoolsID - bio.tools identifier of the tool.
-        - homepage - Homepage URL of the tool.
-        - license - License of the tool.
-        - topic - List of topics associated with the tool.
-        - description - Description of the tool.
+        The bio.tools tool metadata as a dictionary.
+        Expected keys include:
+        - 'name'       : Name of the tool.
+        - 'biotoolsID' : bio.tools identifier of the tool.
+        - 'homepage'   : Homepage or repository URL of the tool.
+        - 'license'    : License identifier.
+        - 'topic'      : List of topics associated with the tool.
+        - 'description': Textual description of the tool.
 
     Returns
     -------
     dict[str, Any]
-        A dictionary with the CITATION.cff base content.
+        A base CFF dictionary containing core tool metadata
+        and a `cff-version` of 1.2.0.
     """
     name = bt_params.get("name", None)
     biotools_id = bt_params.get("biotoolsID", None)
@@ -218,27 +253,31 @@ def _merge_top_level_metadata(
     base_cff: dict[str, Any],
 ) -> dict[str, Any]:
     """
-    Merge top-level CFF metadata.
+    Merge top-level metadata from an existing CITATION.cff with bio.tools metadata.
 
     Policy:
-    - If no existing CITATION.cff, return base_cff as is.
-    - Otherwise, start from existing CITATION.cff.
-    - For known top-level keys we manage:
-      - If existing has a non-empty value, keep it.
-      - If existing is missing/empty, fill from base_cff.
-    - Never touch 'references' or 'preferred-citation' here; they are handled separately.
+    - If no existing CITATION.cff is provided, `base_cff` is returned as-is.
+    - Otherwise, start from the existing CFF.
+    - For keys present in `base_cff`:
+      - If the existing CFF has a non-empty value, it is kept.
+      - If the existing value is missing or empty (None, "", []), the value
+        from `base_cff` is used.
+    - The keys 'references' and 'preferred-citation' are removed here and are
+      handled separately by publication-specific logic.
 
     Parameters
     ----------
     existing_cff : dict[str, Any] | None
-        The existing CITATION.cff content from the GitHub repository.
+        The parsed content of an existing CITATION.cff file,
+        or ``None`` if no file exists.
     base_cff : dict[str, Any]
-        The base CITATION.cff content generated from bio.tools metadata.
+        The base CFF content derived from bio.tools metadata.
 
     Returns
     -------
     dict[str, Any]
-        The merged CITATION.cff content.
+        A merged CFF dictionary containing top-level metadata from both
+        sources, with existing values preserved where present.
     """
     if existing_cff is None:
         return base_cff
@@ -265,19 +304,27 @@ def _extract_gh_references(
     gh_citation_cff: dict[str, Any] | None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
-    Extract references and preferred-citation from an existing CITATION.cff dict.
+    Extract publication information from an existing CITATION.cff dictionary.
+
+    This helper parses an existing CFF structure and returns:
+    - the list of reference entries, and
+    - the preferred-citation entry, if present.
+
+    The preferred citation is ensured to be part of the references list:
+    if it is not already present, it is appended.
 
     Parameters
     ----------
     gh_citation_cff : dict[str, Any] | None
-        The existing CITATION.cff content from the GitHub repository.
+        TParsed content of an existing CITATION.cff file,
+        or ``None`` if no file exists.
 
     Returns
     -------
     tuple[list[dict[str, Any]], dict[str, Any] | None]
-        A tuple containing:
-        - A list of references extracted from the CITATION.cff.
-        - The preferred-citation extracted from the CITATION.cff, or None if not present
+        A tuple of:
+        - A list of reference dictionaries extracted from the CFF.
+        - The preferred-citation dictionary, or ``None`` if not present.
     """
     if not gh_citation_cff:
         return [], None
@@ -316,22 +363,33 @@ def _compose_citation(
     preferred: Publication | dict[str, Any] | None,
 ) -> dict[str, Any]:
     """
-    Generate a CITATION.cff dict from bio.tools metadata and references.
-    If there are no references, a minimal CITATION.cff is created.
+    Combine top-level metadata and publication information into a CFF structure.
+
+    This function takes a base CFF dictionary (already merged with any
+    existing CITATION.cff metadata), a list of references, and an optional
+    preferred-citation, and produces the final CFF dictionary that will be
+    written to `CITATION.cff`.
+
+    Behaviour:
+    - If no references are provided, a minimal CFF file is created with a
+      generic citation message.
+    - If references exist, they are added as a `references` list, and a
+      `preferred-citation` entry is included if one was selected.
 
     Parameters
     ----------
     base_cff : dict[str, Any]
-        The base CITATION.cff content.
+        The top-level CFF metadata.
     references : list[Publication | dict[str, Any]]
-        List of all publications to be included in CITATION.cff.
+        All references to include in the CFF file.
     preferred : Publication | dict[str, Any] | None
-        The selected preferred citation to be included in CITATION.cff, if any.
+        The preferred citation to include, or ``None`` if no preferred
+        citation should be set.
 
     Returns
     -------
     dict[str, Any]
-        A dictionary with the CITATION.cff content.
+        The complete CFF dictionary.
     """
     if not references:
         base_cff["message"] = "If you use this software, please cite it using this CITATION.cff."
@@ -354,28 +412,42 @@ def _compose_citation(
 
 async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any]) -> dict[str, str]:
     """
-    Generate CITATION.cff content from the publications of a bio.tools tool.
-    It uses Europe PMC to resolve publication metadata.
+    Generate or update a CITATION.cff file based on bio.tools and Europe PMC metadata.
+
+    Steps performed:
+    1. Reads publication metadata from a bio.tools tool entry.
+    2. Resolves each publication via the Europe PMC API to obtain
+       bibliographic metadata.
+    3. Optionally parses an existing CITATION.cff (if provided) and extracts
+       existing references and a preferred-citation.
+    4. Merges existing references and new references, deduplicating based on
+       DOI/PMID/PMCID/title.
+    5. Chooses a preferred citation following the configured precedence rules.
+    6. Merges top-level metadata from the existing CFF and bio.tools.
+    7. Returns a dictionary mapping `"CITATION.cff"` to the YAML-serialized
+       CFF content.
 
     Parameters
     ----------
     gh_citation_cff : dict[str, Any]
-        The existing CITATION.cff content from the GitHub repository.
+        Parsed content of an existing CITATION.cff file from the GitHub
+        repository, or ``None`` if no file exists.
     bt_params : dict[str, Any]
-        The bio.tools tool relevant metadata as a dictionary.
-        Should contain:
-        - publication - List of publication items from bio.tools metadata.
-        - name - Name of the tool.
-        - biotoolsID - bio.tools identifier of the tool.
-        - homepage - Homepage URL of the tool.
-        - license - License of the tool.
-        - topic - List of topics associated with the tool.
-        - description - Description of the tool.
+        The bio.tools tool metadata as a dictionary.
+        Expected keys include:
+        - 'publication' : list of publication items from bio.tools metadata.
+        - 'name'        : name of the tool.
+        - 'biotoolsID'  : bio.tools identifier.
+        - 'homepage'    : homepage or repository URL.
+        - 'license'     : license identifier.
+        - 'topic'       : list of topics.
+        - 'description' : description of the tool.
 
     Returns
     -------
     dict[str, str]
-        A dictionary with the filename as key and the CITATION.cff content as value.
+        A dictionary with the filename `"CITATION.cff"` as key,
+        and the YAML-formatted CFF content content as value.
     """
     bt_publication = bt_params.get("publication", None)
 

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -16,7 +16,7 @@ import yaml
 from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import PublicationItem, TypeEnum2
-from bridge.pipelines.utils import to_primitive
+from bridge.pipelines.utils import object_to_primitive
 
 # TODO: add logging
 
@@ -83,7 +83,7 @@ def _compose_citation(bt_params: dict[str, Any], references: list[Publication]):
             }
         )
 
-    primitive_cff = to_primitive(base_cff)
+    primitive_cff = object_to_primitive(base_cff)
     return {"CITATION.cff": yaml.dump(primitive_cff, sort_keys=False)}
 
 

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -3,6 +3,7 @@ Utilities for pipelines.
 """
 
 from .badges import Badge, compose_badge
+from .conversions import to_primitive
 from .decorators import prepare_match_items
 from .file_checks import check_file_with_extension_exists
 from .templating import fill_template, remove_first_snippet_from_text
@@ -14,4 +15,5 @@ __all__ = [
     "compose_badge",
     "fill_template",
     "remove_first_snippet_from_text",
+    "to_primitive",
 ]

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -3,7 +3,8 @@ Utilities for pipelines.
 """
 
 from .badges import Badge, compose_badge
-from .conversions import to_primitive
+from .cleaning import canonicalize_shields_url, canonicalize_url, escape_shields_part, normalize_color
+from .conversions import object_to_primitive, svg_to_base64
 from .decorators import prepare_match_items
 from .file_checks import check_file_with_extension_exists
 from .templating import fill_template, remove_first_snippet_from_text
@@ -13,7 +14,12 @@ __all__ = [
     "check_file_with_extension_exists",
     "Badge",
     "compose_badge",
+    "canonicalize_shields_url",
+    "canonicalize_url",
+    "escape_shields_part",
+    "normalize_color",
     "fill_template",
     "remove_first_snippet_from_text",
-    "to_primitive",
+    "svg_to_base64",
+    "object_to_primitive",
 ]

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -14,12 +14,13 @@ from .cleaning import (
 )
 from .conversions import object_to_primitive, svg_to_base64
 from .decorators import prepare_match_items
-from .file_checks import check_file_with_extension_exists
+from .files import check_file_with_extension_exists, get_file_content
 from .templating import fill_template, remove_first_snippet_from_text
 
 __all__ = [
     "prepare_match_items",
     "check_file_with_extension_exists",
+    "get_file_content",
     "Badge",
     "compose_badge",
     "canonicalize_shields_url",

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -3,7 +3,15 @@ Utilities for pipelines.
 """
 
 from .badges import Badge, compose_badge
-from .cleaning import canonicalize_shields_url, canonicalize_url, escape_shields_part, normalize_color, normalize_text
+from .cleaning import (
+    canonicalize_shields_url,
+    canonicalize_url,
+    escape_shields_part,
+    normalize_color,
+    normalize_dict_strings,
+    normalize_pydantic_model_strings,
+    normalize_text,
+)
 from .conversions import object_to_primitive, svg_to_base64
 from .decorators import prepare_match_items
 from .file_checks import check_file_with_extension_exists
@@ -19,6 +27,8 @@ __all__ = [
     "escape_shields_part",
     "normalize_color",
     "normalize_text",
+    "normalize_dict_strings",
+    "normalize_pydantic_model_strings",
     "fill_template",
     "remove_first_snippet_from_text",
     "svg_to_base64",

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -3,7 +3,7 @@ Utilities for pipelines.
 """
 
 from .badges import Badge, compose_badge
-from .cleaning import canonicalize_shields_url, canonicalize_url, escape_shields_part, normalize_color
+from .cleaning import canonicalize_shields_url, canonicalize_url, escape_shields_part, normalize_color, normalize_text
 from .conversions import object_to_primitive, svg_to_base64
 from .decorators import prepare_match_items
 from .file_checks import check_file_with_extension_exists
@@ -18,6 +18,7 @@ __all__ = [
     "canonicalize_url",
     "escape_shields_part",
     "normalize_color",
+    "normalize_text",
     "fill_template",
     "remove_first_snippet_from_text",
     "svg_to_base64",

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -14,13 +14,14 @@ from .cleaning import (
 )
 from .conversions import object_to_primitive, svg_to_base64
 from .decorators import prepare_match_items
-from .files import check_file_with_extension_exists, get_file_content
+from .files import check_file_with_extension_exists, get_file_content, load_dict_from_yaml_file
 from .templating import fill_template, remove_first_snippet_from_text
 
 __all__ = [
     "prepare_match_items",
     "check_file_with_extension_exists",
     "get_file_content",
+    "load_dict_from_yaml_file",
     "Badge",
     "compose_badge",
     "canonicalize_shields_url",

--- a/src/bridge/pipelines/utils/badges.py
+++ b/src/bridge/pipelines/utils/badges.py
@@ -2,69 +2,10 @@
 Utilities for handling asset files in pipelines.
 """
 
-import base64
-import re
-from pathlib import Path
-from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
-
 from pydantic import BaseModel
 
-
-def _canonicalize_shields_url(url: str) -> str:
-    """
-    Canonicalize a shields.io URL by removing the "logo" query parameter.
-
-    Parameters
-    ----------
-    url : str
-        The shields.io URL to canonicalize.
-
-    Returns
-    -------
-    str
-        The canonicalized URL.
-    """
-    if "img.shields.io" not in url:
-        return url
-
-    parts = urlsplit(url)
-    # parse query params, drop any "logo" parameter, sort rest for stability
-    q_pairs = parse_qsl(parts.query, keep_blank_values=True)
-    q_pairs = [(k, v) for (k, v) in q_pairs if k.lower() != "logo"]
-    q_pairs.sort()
-    new_query = urlencode(q_pairs)
-
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
-
-
-def _canonicalize_url(url: str) -> str:
-    """
-    Canonicalize a URL by normalizing its components.
-
-    Parameters
-    ----------
-    url : str
-        The URL to canonicalize.
-
-    Returns
-    -------
-    str
-        The canonicalized URL.
-    """
-    parsed = urlparse(url)
-
-    query = urlencode(sorted(parse_qsl(parsed.query)), doseq=True)
-    path = parsed.path.rstrip("/") or "/"
-
-    return urlunparse(
-        parsed._replace(
-            scheme=parsed.scheme.lower(),
-            netloc=parsed.netloc.lower(),
-            path=path,
-            query=query,
-            fragment="",
-        )
-    )
+from .cleaning import canonicalize_shields_url, canonicalize_url, escape_shields_part, normalize_color
+from .conversions import svg_to_base64
 
 
 class Badge(BaseModel):
@@ -108,8 +49,8 @@ class Badge(BaseModel):
         """
         Canonical semantic identity of the badge.
         """
-        img = _canonicalize_shields_url(str(self.image_url))
-        link = _canonicalize_url(self.link_url) if self.link_url is not None else None
+        img = canonicalize_shields_url(str(self.image_url))
+        link = canonicalize_url(self.link_url) if self.link_url is not None else None
         return img, link
 
     def __eq__(self, other: object) -> bool:
@@ -119,44 +60,6 @@ class Badge(BaseModel):
 
     def __hash__(self) -> int:
         return hash(self._signature())
-
-
-def _escape_shields_part(value: str) -> str:
-    """
-    Prepare label/message for the Shields path segment.
-
-    Shields semantics:
-    - `-`  = separator
-    - `--` = literal `-`
-    - `_`  = space
-    - `__` = literal `_`
-    """
-    value = str(value)
-    value = value.replace("-", "--")
-    value = value.replace("_", "__")
-    return quote(value, safe="_")
-
-
-def _normalize_color(value: str) -> str:
-    """
-    Normalize a color for Shields:
-    - Strip leading '#' if present.
-    - Percent-encode anything weird.
-
-    Parameters
-    ----------
-    value : str
-        The color value to normalize.
-
-    Returns
-    -------
-    str
-        The normalized color string.
-    """
-    value = str(value).strip()
-    if value.startswith("#"):
-        value = value[1:]
-    return quote(value, safe="")
 
 
 def _make_shields_badge_url(
@@ -189,11 +92,11 @@ def _make_shields_badge_url(
     """
     base = "https://img.shields.io/badge"
 
-    label_enc = _escape_shields_part(label)
-    message_enc = _escape_shields_part(message)
-    color_enc = _normalize_color(color)
+    label_enc = escape_shields_part(label)
+    message_enc = escape_shields_part(message)
+    color_enc = normalize_color(color)
 
-    label_color_enc = _normalize_color(label_color)
+    label_color_enc = normalize_color(label_color)
     url = f"{base}/{label_enc}-{message_enc}-{color_enc}.svg?labelColor={label_color_enc}"
 
     if logo_b64 is not None:
@@ -203,44 +106,6 @@ def _make_shields_badge_url(
         url += f"&logo={logo_param}"
 
     return url
-
-
-def _svg_to_base64(svg_path: str) -> str:
-    """
-    Convert an SVG file to a base64-encoded string.
-
-    Parameters
-    ----------
-    svg_path : str
-        Path to the SVG file.
-
-    Returns
-    -------
-    str
-        Base64-encoded string of the SVG content.
-
-    Raises
-    ------
-    FileNotFoundError
-        If the SVG file does not exist.
-    """
-    svg_path = Path(svg_path)
-    if not svg_path.exists():
-        raise FileNotFoundError(f"SVG file not found: {svg_path}")
-
-    text = svg_path.read_text(encoding="utf-8")
-
-    # remove XML declaration if present
-    text = re.sub(r"^<\?xml[^>]*\?>\s*", "", text, flags=re.IGNORECASE)
-
-    # strip comments
-    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
-
-    # collapse trivial whitespace between tags
-    text = re.sub(r">\s+<", "><", text).strip()
-
-    encoded_svg = base64.b64encode(text.encode("utf-8")).decode("ascii").replace("\n", "")
-    return encoded_svg
 
 
 def compose_badge(
@@ -278,7 +143,7 @@ def compose_badge(
     Badge
         The constructed Badge object.
     """
-    logo_b64 = _svg_to_base64(svg_path) if svg_path is not None else None
+    logo_b64 = svg_to_base64(svg_path) if svg_path is not None else None
     badge_url = _make_shields_badge_url(
         label=label,
         message=message,

--- a/src/bridge/pipelines/utils/cleaning.py
+++ b/src/bridge/pipelines/utils/cleaning.py
@@ -1,0 +1,100 @@
+"""
+Utilities for cleaning and canonicalizing objects.
+"""
+
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
+
+
+def canonicalize_shields_url(url: str) -> str:
+    """
+    Canonicalize a shields.io URL by removing the "logo" query parameter.
+
+    Parameters
+    ----------
+    url : str
+        The shields.io URL to canonicalize.
+
+    Returns
+    -------
+    str
+        The canonicalized URL.
+    """
+    if "img.shields.io" not in url:
+        return url
+
+    parts = urlsplit(url)
+    # parse query params, drop any "logo" parameter, sort rest for stability
+    q_pairs = parse_qsl(parts.query, keep_blank_values=True)
+    q_pairs = [(k, v) for (k, v) in q_pairs if k.lower() != "logo"]
+    q_pairs.sort()
+    new_query = urlencode(q_pairs)
+
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+
+
+def canonicalize_url(url: str) -> str:
+    """
+    Canonicalize a URL by normalizing its components.
+
+    Parameters
+    ----------
+    url : str
+        The URL to canonicalize.
+
+    Returns
+    -------
+    str
+        The canonicalized URL.
+    """
+    parsed = urlparse(url)
+
+    query = urlencode(sorted(parse_qsl(parsed.query)), doseq=True)
+    path = parsed.path.rstrip("/") or "/"
+
+    return urlunparse(
+        parsed._replace(
+            scheme=parsed.scheme.lower(),
+            netloc=parsed.netloc.lower(),
+            path=path,
+            query=query,
+            fragment="",
+        )
+    )
+
+
+def escape_shields_part(value: str) -> str:
+    """
+    Prepare label/message for the Shields path segment.
+
+    Shields semantics:
+    - `-`  = separator
+    - `--` = literal `-`
+    - `_`  = space
+    - `__` = literal `_`
+    """
+    value = str(value)
+    value = value.replace("-", "--")
+    value = value.replace("_", "__")
+    return quote(value, safe="_")
+
+
+def normalize_color(value: str) -> str:
+    """
+    Normalize a color for Shields:
+    - Strip leading '#' if present.
+    - Percent-encode anything weird.
+
+    Parameters
+    ----------
+    value : str
+        The color value to normalize.
+
+    Returns
+    -------
+    str
+        The normalized color string.
+    """
+    value = str(value).strip()
+    if value.startswith("#"):
+        value = value[1:]
+    return quote(value, safe="")

--- a/src/bridge/pipelines/utils/cleaning.py
+++ b/src/bridge/pipelines/utils/cleaning.py
@@ -2,6 +2,8 @@
 Utilities for cleaning and canonicalizing objects.
 """
 
+import html
+import re
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
 
 
@@ -98,3 +100,34 @@ def normalize_color(value: str) -> str:
     if value.startswith("#"):
         value = value[1:]
     return quote(value, safe="")
+
+
+def normalize_text(value: str | None) -> str | None:
+    """
+    Decode HTML entities, strip tags, and normalise odd characters.
+
+    Parameters
+    ----------
+    value : str | None
+        The text to normalize.
+
+    Returns
+    -------
+    str | None
+        The normalized text, or None if input was None.
+    """
+    if value is None:
+        return None
+
+    # decode HTML entities: &lt;i&gt; → <i>, &amp; → &, etc.
+    text = html.unescape(value)
+
+    # strip any remaining HTML tags: <i>name</i> -> name
+    tag_re = re.compile(r"<[^>]+>")
+    text = tag_re.sub("", text)
+
+    # replace box-drawing dash with a normal ASCII dash
+    text = text.replace("\u2500", " - ")
+
+    # strip outer whitespace
+    return text.strip()

--- a/src/bridge/pipelines/utils/cleaning.py
+++ b/src/bridge/pipelines/utils/cleaning.py
@@ -1,5 +1,9 @@
 """
 Utilities for cleaning and canonicalizing objects.
+
+The functions are intentionally conservative: they avoid guessing semantics
+and focus only on reversible, mechanical clean-ups and canonical forms that
+improve comparison and stability.
 """
 
 import html
@@ -10,7 +14,18 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunp
 
 def canonicalize_shields_url(url: str) -> str:
     """
-    Canonicalize a shields.io URL by removing the "logo" query parameter.
+    Canonicalize a shields.io image URL for stable comparison.
+
+    This helper focuses on shields.io badge URLs served from `img.shields.io`.
+    The main goal is to strip out purely cosmetic parameters that shouldn't
+    affect logical equality (e.g. user-chosen logos) and to provide a stable
+    query parameter ordering.
+
+    Behaviour:
+    - If the URL does *not* contain `img.shields.io`, it is returned unchanged.
+    - If it does, the query string is parsed, the `logo` parameter is removed
+      (case-insensitive), and the remaining parameters are sorted
+      lexicographically and re-encoded.
 
     Parameters
     ----------
@@ -20,7 +35,7 @@ def canonicalize_shields_url(url: str) -> str:
     Returns
     -------
     str
-        The canonicalized URL.
+        The canonicalized URL, suitable for equality checks or deduplication.
     """
     if "img.shields.io" not in url:
         return url
@@ -37,7 +52,18 @@ def canonicalize_shields_url(url: str) -> str:
 
 def canonicalize_url(url: str) -> str:
     """
-    Canonicalize a URL by normalizing its components.
+    Canonicalize a generic URL for stable comparison.
+
+    This performs a minimal, well-defined normalization intended to make
+    string-based URL comparisons less fragile without changing semantics
+    for typical HTTP(S) URLs.
+
+    Normalizations applied:
+    - Lowercase the scheme and netloc (host + port).
+    - Strip trailing slashes from the path, but ensure the path is at least "/".
+    - Parse the query string into key/value pairs, sort them, and re-encode
+      (preserving multiplicity via `doseq=True`).
+    - Drop the fragment entirely (anything after '#').
 
     Parameters
     ----------
@@ -67,13 +93,35 @@ def canonicalize_url(url: str) -> str:
 
 def escape_shields_part(value: str) -> str:
     """
-    Prepare label/message for the Shields path segment.
+    Prepare a label or message for use in a Shields.io badge path segment.
 
-    Shields semantics:
-    - `-`  = separator
+    Shields.io encodes meaning into certain characters in the path portion
+    of the URL. This function escapes a free-form string so that it can be
+    safely embedded in that position without accidentally triggering
+    Shields' special syntax.
+
+    Shields path semantics:
+    - `-`  = segment separator
     - `--` = literal `-`
     - `_`  = space
     - `__` = literal `_`
+
+    This function:
+    - Converts `-` to `--`.
+    - Converts `_` to `__`.
+    - Percent-encodes anything else that needs escaping, but leaves `_`
+      unchanged so that Shields can interpret it as a space.
+
+    Parameters
+    ----------
+    value : str
+        The label or message to escape.
+
+    Returns
+    -------
+    str
+        The escaped value, suitable for direct inclusion in a Shields.io URL
+        path segment.
     """
     value = str(value)
     value = value.replace("-", "--")
@@ -83,19 +131,23 @@ def escape_shields_part(value: str) -> str:
 
 def normalize_color(value: str) -> str:
     """
-    Normalize a color for Shields:
-    - Strip leading '#' if present.
-    - Percent-encode anything weird.
+    Normalize a color value by stripping a leading '#' and percent-encoding.
+
+    Behaviour:
+    - Coerces the value to a string and strips surrounding whitespace.
+    - Removes a leading `#` if present.
+    - Percent-encodes the remaining value with no safe characters.
 
     Parameters
     ----------
     value : str
-        The color value to normalize.
+        The color value to normalize (e.g. "#4c1", "brightgreen").
 
     Returns
     -------
     str
-        The normalized color string.
+        The normalized color string, without a leading '#', and
+        percent-encoded for safe use in URLs.
     """
     value = str(value).strip()
     if value.startswith("#"):
@@ -105,19 +157,35 @@ def normalize_color(value: str) -> str:
 
 def normalize_text(value: str | None, normalize_multiline: bool = True) -> str | None:
     """
-    Decode HTML entities, strip tags, and normalise odd characters.
+    Clean and normalize free-text values.
+
+    This is a general-purpose text scrubber intended to remove presentation
+    artefacts (HTML entities/tags, box-drawing characters) and normalize
+    whitespace so that strings are more suitable for storage, comparison,
+    or inclusion in metadata formats.
+
+    Steps performed:
+    1. Decode HTML entities (e.g. ``&lt;i&gt;`` → ``<i>``, ``&amp;`` → ``&``).
+    2. Strip all remaining HTML tags (e.g. ``<i>name</i>`` → ``name``).
+    3. Replace the box-drawing dash ``\u2500`` with a plain ASCII ``-``.
+    4. Remove non-printable characters.
+    5. Optionally collapse all whitespace, including newlines, into single
+       spaces (`normalize_multiline=True`).
+    6. Strip leading and trailing whitespace.
 
     Parameters
     ----------
     value : str | None
-        The text to normalize.
+        The text to normalize. If ``None``, the function returns ``None``.
     normalize_multiline : bool, optional
-        Whether to normalize multiple lines by replacing newlines with spaces, by default True.
+        If True (default), newlines and runs of whitespace are collapsed into
+        single spaces. If False, existing line breaks are preserved and only
+        non-printable characters and HTML artefacts are removed.
 
     Returns
     -------
     str | None
-        The normalized text, or None if input was None.
+        The normalized text, or ``None`` if the input was ``None``.
     """
     if value is None:
         return None
@@ -143,50 +211,119 @@ def normalize_text(value: str | None, normalize_multiline: bool = True) -> str |
     return text.strip()
 
 
-def normalize_dict_strings(d: dict[str, Any]) -> dict[str, Any]:
+def _normalize_structure(obj: Any) -> Any:
     """
-    Normalize all string values in a dictionary using `normalize_text`.
+    Recursively normalize strings inside common container types.
+
+    This helper is used by higher-level normalization functions to apply
+    :func:`normalize_text` to all string-like values in nested structures.
+
+    Supported types:
+    - str / None: passed through `normalize_text`.
+    - dict: keys left as-is, values normalized recursively.
+    - list, tuple, set: elements normalized recursively, container type preserved.
+    - Pydantic models: delegated to `normalize_pydantic_model_strings`.
+    - Anything else: returned unchanged.
 
     Parameters
     ----------
-    d : dict[str, Any]
-        The dictionary to normalize.
-
-    Returns
-    -------
-    dict[str, Any]
-        The dictionary with normalized string values.
-    """
-    normalized = {}
-    for k, v in d.items():
-        if isinstance(v, str) or v is None:
-            normalized[k] = normalize_text(v)
-        else:
-            normalized[k] = v
-    return normalized
-
-
-def normalize_pydantic_model_strings(model: Any) -> Any:
-    """
-    Normalize all string fields in a Pydantic model using `normalize_text`.
-
-    Parameters
-    ----------
-    model : Any
-        The Pydantic model to normalize.
+    obj : Any
+        Arbitrary Python object to normalize.
 
     Returns
     -------
     Any
-        The Pydantic model with normalized string fields.
+        A normalized version of `obj`, with the same overall structure.
     """
-    if not hasattr(model, "__fields__"):
+    # scalar text
+    if isinstance(obj, str) or obj is None:
+        return normalize_text(obj)
+
+    # dict: normalize values recursively, keep keys untouched
+    if isinstance(obj, dict):
+        return {k: _normalize_structure(v) for k, v in obj.items()}
+
+    # lists: normalize each element, keep as list
+    if isinstance(obj, list):
+        return [_normalize_structure(v) for v in obj]
+
+    # tuples: normalize each element, keep as tuple
+    if isinstance(obj, tuple):
+        return tuple(_normalize_structure(v) for v in obj)
+
+    # sets: normalize each element, keep as set
+    if isinstance(obj, set):
+        return {_normalize_structure(v) for v in obj}
+
+    # Pydantic model: normalize fields in-place, return the same object
+    if hasattr(obj, "model_fields") or hasattr(obj, "__fields__"):
+        return normalize_pydantic_model_strings(obj)
+
+    return obj
+
+
+def normalize_dict_strings(d: dict[str, Any]) -> dict[str, Any]:
+    """
+    Recursively normalize all string-like values in a dictionary.
+
+    This function walks the entire structure of the given dict and applies
+    :func:`normalize_text` to any string or ``None`` value it encounters.
+
+    Keys are left unchanged. Non-string scalar values (numbers, booleans, etc.)
+    are preserved as-is.
+
+    Parameters
+    ----------
+    d : dict[str, Any]
+        The dictionary whose string values (and nested structures) should be
+        normalized.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new dictionary with the same structure as `d`, where all nested
+        string/None values have been normalized.
+    """
+    return _normalize_structure(d)
+
+
+def normalize_pydantic_model_strings(model: Any) -> Any:
+    """
+    Recursively normalize all string fields in a Pydantic model in-place.
+
+    For each declared field on the model:
+
+    - If the current value is a string or ``None``, it is passed through
+      :func:`normalize_text`.
+    - If the current value is a container (dict, list, tuple, set), its
+      contents are normalized recursively via :func:`_normalize_structure`.
+    - If the current value is another Pydantic model, it is normalized
+      recursively by calling `normalize_pydantic_model_strings` on it.
+
+    If the object does not look like a Pydantic model (i.e. has neither
+    ``model_fields`` nor ``__fields__``), it is returned unchanged.
+
+    Parameters
+    ----------
+    model : Any
+        The Pydantic model instance to normalize, or any other object.
+
+    Returns
+    -------
+    Any
+        The same ``model`` object, potentially modified in-place if it is a
+        Pydantic model with string fields or nested containers.
+    """
+    if hasattr(model, "model_fields"):
+        fields = model.model_fields
+    elif hasattr(model, "__fields__"):
+        fields = model.__fields__
+    else:
         return model
 
-    for field_name, _field in model.__fields__.items():
-        value = getattr(model, field_name)
-        if isinstance(value, str) or value is None:
-            normalized_value = normalize_text(value)
-            setattr(model, field_name, normalized_value)
+    for field_name in fields.keys():
+        value = getattr(model, field_name, None)
+        normalized_value = _normalize_structure(value)
+        setattr(model, field_name, normalized_value)
 
     return model

--- a/src/bridge/pipelines/utils/cleaning.py
+++ b/src/bridge/pipelines/utils/cleaning.py
@@ -103,7 +103,7 @@ def normalize_color(value: str) -> str:
     return quote(value, safe="")
 
 
-def normalize_text(value: str | None) -> str | None:
+def normalize_text(value: str | None, normalize_multiline: bool = True) -> str | None:
     """
     Decode HTML entities, strip tags, and normalise odd characters.
 
@@ -111,6 +111,8 @@ def normalize_text(value: str | None) -> str | None:
     ----------
     value : str | None
         The text to normalize.
+    normalize_multiline : bool, optional
+        Whether to normalize multiple lines by replacing newlines with spaces, by default True.
 
     Returns
     -------
@@ -128,7 +130,14 @@ def normalize_text(value: str | None) -> str | None:
     text = tag_re.sub("", text)
 
     # replace box-drawing dash with a normal ASCII dash
-    text = text.replace("\u2500", " - ")
+    text = text.replace("\u2500", "-")
+
+    # drop non-printable characters
+    text = "".join(c for c in text if c.isprintable())
+
+    if normalize_multiline:
+        # replace newlines and multiple spaces with a single space
+        text = re.sub(r"\s+", " ", text)
 
     # strip outer whitespace
     return text.strip()

--- a/src/bridge/pipelines/utils/cleaning.py
+++ b/src/bridge/pipelines/utils/cleaning.py
@@ -4,6 +4,7 @@ Utilities for cleaning and canonicalizing objects.
 
 import html
 import re
+from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
 
 
@@ -131,3 +132,52 @@ def normalize_text(value: str | None) -> str | None:
 
     # strip outer whitespace
     return text.strip()
+
+
+def normalize_dict_strings(d: dict[str, Any]) -> dict[str, Any]:
+    """
+    Normalize all string values in a dictionary using `normalize_text`.
+
+    Parameters
+    ----------
+    d : dict[str, Any]
+        The dictionary to normalize.
+
+    Returns
+    -------
+    dict[str, Any]
+        The dictionary with normalized string values.
+    """
+    normalized = {}
+    for k, v in d.items():
+        if isinstance(v, str) or v is None:
+            normalized[k] = normalize_text(v)
+        else:
+            normalized[k] = v
+    return normalized
+
+
+def normalize_pydantic_model_strings(model: Any) -> Any:
+    """
+    Normalize all string fields in a Pydantic model using `normalize_text`.
+
+    Parameters
+    ----------
+    model : Any
+        The Pydantic model to normalize.
+
+    Returns
+    -------
+    Any
+        The Pydantic model with normalized string fields.
+    """
+    if not hasattr(model, "__fields__"):
+        return model
+
+    for field_name, _field in model.__fields__.items():
+        value = getattr(model, field_name)
+        if isinstance(value, str) or value is None:
+            normalized_value = normalize_text(value)
+            setattr(model, field_name, normalized_value)
+
+    return model

--- a/src/bridge/pipelines/utils/conversions.py
+++ b/src/bridge/pipelines/utils/conversions.py
@@ -1,0 +1,47 @@
+"""
+Utility functions for converting object types.
+"""
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def to_primitive(obj: Any) -> Any:
+    """
+    Recursively convert Pydantic models and other custom types to plain Python types.
+
+    Parameters
+    ----------
+    obj : Any
+        The object to convert.
+
+    Returns
+    -------
+    Any
+        The converted object with only primitive types (dicts, lists, strings, numbers, booleans, None).
+    """
+    # Pydantic models
+    if isinstance(obj, BaseModel):
+        # v2
+        if hasattr(obj, "model_dump"):
+            data = obj.model_dump(mode="python", exclude_none=True)
+        else:  # v1 fallback
+            data = obj.dict(exclude_none=True)
+        return to_primitive(data)
+
+    # enums
+    if isinstance(obj, Enum):
+        return obj.value
+
+    # dicts
+    if isinstance(obj, dict):
+        return {k: to_primitive(v) for k, v in obj.items()}
+
+    # lists / tuples / sets
+    if isinstance(obj, (list, tuple, set)):
+        return [to_primitive(v) for v in obj]
+
+    # everything else is assumed to already be primitive or stringify-able
+    return obj

--- a/src/bridge/pipelines/utils/conversions.py
+++ b/src/bridge/pipelines/utils/conversions.py
@@ -2,13 +2,54 @@
 Utility functions for converting object types.
 """
 
+import base64
+import re
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
 
 
-def to_primitive(obj: Any) -> Any:
+def svg_to_base64(svg_path: str) -> str:
+    """
+    Convert an SVG file to a base64-encoded string.
+
+    Parameters
+    ----------
+    svg_path : str
+        Path to the SVG file.
+
+    Returns
+    -------
+    str
+        Base64-encoded string of the SVG content.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the SVG file does not exist.
+    """
+    svg_path = Path(svg_path)
+    if not svg_path.exists():
+        raise FileNotFoundError(f"SVG file not found: {svg_path}")
+
+    text = svg_path.read_text(encoding="utf-8")
+
+    # remove XML declaration if present
+    text = re.sub(r"^<\?xml[^>]*\?>\s*", "", text, flags=re.IGNORECASE)
+
+    # strip comments
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+    # collapse trivial whitespace between tags
+    text = re.sub(r">\s+<", "><", text).strip()
+
+    encoded_svg = base64.b64encode(text.encode("utf-8")).decode("ascii").replace("\n", "")
+    return encoded_svg
+
+
+def object_to_primitive(obj: Any) -> Any:
     """
     Recursively convert Pydantic models and other custom types to plain Python types.
 
@@ -29,7 +70,7 @@ def to_primitive(obj: Any) -> Any:
             data = obj.model_dump(mode="python", exclude_none=True)
         else:  # v1 fallback
             data = obj.dict(exclude_none=True)
-        return to_primitive(data)
+        return object_to_primitive(data)
 
     # enums
     if isinstance(obj, Enum):
@@ -37,11 +78,11 @@ def to_primitive(obj: Any) -> Any:
 
     # dicts
     if isinstance(obj, dict):
-        return {k: to_primitive(v) for k, v in obj.items()}
+        return {k: object_to_primitive(v) for k, v in obj.items()}
 
     # lists / tuples / sets
     if isinstance(obj, (list, tuple, set)):
-        return [to_primitive(v) for v in obj]
+        return [object_to_primitive(v) for v in obj]
 
     # everything else is assumed to already be primitive or stringify-able
     return obj

--- a/src/bridge/pipelines/utils/conversions.py
+++ b/src/bridge/pipelines/utils/conversions.py
@@ -1,5 +1,8 @@
 """
-Utility functions for converting object types.
+Utility functions for converting object types and preparing them for serialization.
+
+This module provides small, focused helpers that are useful when generating
+artifacts such as YAML, JSON, or Markdown documents from richer Python objects.
 """
 
 import base64
@@ -13,22 +16,31 @@ from pydantic import BaseModel
 
 def svg_to_base64(svg_path: str) -> str:
     """
-    Convert an SVG file to a base64-encoded string.
+    Convert an SVG file into a cleaned, base64-encoded string.
+
+    This helper is intended for scenarios where an SVG needs to be embedded
+    directly into another format (e.g. HTML `img` tags with data URIs,
+    Markdown, or JSON/YAML configuration files) rather than referenced by
+    filesystem path.
 
     Parameters
     ----------
     svg_path : str
-        Path to the SVG file.
+        Path to the SVG file on disk.
 
     Returns
     -------
     str
-        Base64-encoded string of the SVG content.
+        A base64-encoded string representing the cleaned SVG content. The
+        resulting string contains only ASCII characters and no newlines, and
+        can be safely used in data URIs such as::
+
+            f"data:image/svg+xml;base64,{svg_to_base64('icon.svg')}"
 
     Raises
     ------
     FileNotFoundError
-        If the SVG file does not exist.
+        If the SVG file does not exist at the given path.
     """
     svg_path = Path(svg_path)
     if not svg_path.exists():
@@ -51,24 +63,56 @@ def svg_to_base64(svg_path: str) -> str:
 
 def object_to_primitive(obj: Any) -> Any:
     """
-    Recursively convert Pydantic models and other custom types to plain Python types.
+    Recursively convert complex objects into plain Python types.
+
+    This function walks an arbitrary Python object and produces a structure
+    composed only of "primitive" container-friendly types:
+
+    - ``dict`` with primitive values
+    - ``list`` of primitive values
+    - ``str``, ``int``, ``float``, ``bool``, or ``None``
+
+    It is useful before serializing data to JSON, YAML, or other
+    text-based formats where custom classes (e.g. Pydantic models, enums)
+    would otherwise introduce unwanted artifacts or non-serializable types.
+
+    Conversion rules
+    ----------------
+    - **Pydantic models**:
+      - For v2 models, ``model_dump(mode="python", exclude_none=True)`` is used.
+      - For v1 models, ``dict(exclude_none=True)`` is used.
+      - The resulting dict is then processed recursively.
+
+    - **Enum instances**:
+      - Replaced with their ``.value``.
+
+    - **Mappings / dicts**:
+      - Keys are left as-is, values are passed through ``object_to_primitive``
+        recursively.
+
+    - **Iterables (list, tuple, set)**:
+      - Converted to a ``list`` with each element converted recursively.
+
+    - **Anything else**:
+      - Returned unchanged, under the assumption that it is already a primitive
+        type or is otherwise safely serializable.
 
     Parameters
     ----------
     obj : Any
-        The object to convert.
+        The object (or nested structure of objects) to convert.
 
     Returns
     -------
     Any
-        The converted object with only primitive types (dicts, lists, strings, numbers, booleans, None).
+        A recursively converted object that only contains primitive types and
+        containers thereof.
     """
     # Pydantic models
     if isinstance(obj, BaseModel):
-        # v2
         if hasattr(obj, "model_dump"):
             data = obj.model_dump(mode="python", exclude_none=True)
-        else:  # v1 fallback
+        else:
             data = obj.dict(exclude_none=True)
         return object_to_primitive(data)
 

--- a/src/bridge/pipelines/utils/files.py
+++ b/src/bridge/pipelines/utils/files.py
@@ -1,6 +1,8 @@
 """
-Utility functions for file checks in pipelines.
+Utility functions for files.
 """
+
+from pathlib import Path
 
 
 def check_file_with_extension_exists(in_folder_path: str, file_extension: str) -> bool:
@@ -26,3 +28,24 @@ def check_file_with_extension_exists(in_folder_path: str, file_extension: str) -
             if file.endswith(file_extension):
                 return True
     return False
+
+
+def get_file_content(file_path: str) -> str | None:
+    """
+    Read and return the content of a file.
+
+    Parameters
+    ----------
+    file_path : str
+        The path to the file.
+
+    Returns
+    -------
+    str | None
+        The content of the file. None if the file does not exist.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        return None
+
+    return path.read_text(encoding="utf-8")

--- a/src/bridge/pipelines/utils/files.py
+++ b/src/bridge/pipelines/utils/files.py
@@ -3,6 +3,9 @@ Utility functions for files.
 """
 
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 
 def check_file_with_extension_exists(in_folder_path: str, file_extension: str) -> bool:
@@ -49,3 +52,29 @@ def get_file_content(file_path: str | Path) -> str | None:
         return None
 
     return path.read_text(encoding="utf-8")
+
+
+def load_dict_from_yaml_file(file_path: str | Path) -> dict[str, Any]:
+    """
+    Load a YAML file and return its content as a dictionary.
+
+    Parameters
+    ----------
+    file_path : str | Path
+        The path to the YAML file.
+
+    Returns
+    -------
+    dict[str, Any]
+        The content of the YAML file as a dictionary.
+    """
+    content = get_file_content(file_path)
+    if content is None:
+        return {}
+
+    try:
+        data = yaml.safe_load(content)
+        return data or {}
+    except yaml.YAMLError:
+        # parsing error
+        return {}

--- a/src/bridge/pipelines/utils/files.py
+++ b/src/bridge/pipelines/utils/files.py
@@ -30,13 +30,13 @@ def check_file_with_extension_exists(in_folder_path: str, file_extension: str) -
     return False
 
 
-def get_file_content(file_path: str) -> str | None:
+def get_file_content(file_path: str | Path) -> str | None:
     """
     Read and return the content of a file.
 
     Parameters
     ----------
-    file_path : str
+    file_path : str | Path
         The path to the file.
 
     Returns


### PR DESCRIPTION
## Summary
- Removed artifacts from the generated cff (from pydantic, europe pmc, etc)
- Instead of including only primary publications, we now include all
- Merge metadata from existing CITATION.cff (if any) with bio.tools metadata:
    - top level metadata is preserved, missing keys are updated with bio.tools metadata
    - preferred citation is chosen with a clear precedence: existing preferred-citation (if any) > bio.tools primary publications > other publications.

## Type
- [x] feat
- [x] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #10 #67 