### PR TITLE
Combine similar function in a simple policy

### DIFF
--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/homepage.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/homepage.py
@@ -12,6 +12,7 @@ from pydantic import AnyUrl
 
 from bridge.core.biotools import UrlftpType
 from bridge.logging import get_user_logger
+from bridge.pipelines.policies.gh2bt import reconcile_gh_over_bt
 from bridge.pipelines.utils import canonicalize_url
 
 logger = get_user_logger()
@@ -57,26 +58,29 @@ def map_homepage(gh_schema: dict[str, AnyUrl | str | None], bt_homepage: UrlftpT
         The resolved homepage as a `UrlftpType` instance, or ``None`` if no
         homepage could be determined (only possible if `gh_schema` is malformed).
     """
-    gh_homepage = gh_schema.get("homepage", None)
-    gh_url = gh_schema.get("html_url", None)
+    gh_homepage = gh_schema.get("homepage")
+    gh_url = gh_schema.get("html_url")
 
-    if gh_homepage is not None:
-        if bt_homepage is not None:
-            gh_norm = canonicalize_url(str(gh_homepage))
-            bt_norm = canonicalize_url(str(bt_homepage.root))
+    gh_norm = canonicalize_url(str(gh_homepage)) if gh_homepage is not None else None
+    bt_norm = canonicalize_url(str(bt_homepage.root)) if bt_homepage is not None else None
 
-            if gh_norm == bt_norm:
-                logger.exact(f"GitHub homepage '{gh_norm}' matches bio.tools homepage.")
-                return bt_homepage
-
-            logger.conflict(f"existing GitHub homepage '{gh_norm}'" f" differs from bio.tools homepage '{bt_norm}'")
-
-        logger.added(f"homepage '{gh_homepage}' from GitHub")
-        return UrlftpType(root=str(gh_homepage))
-
-    if gh_homepage is None and bt_homepage is None:
+    if gh_norm is None and bt_homepage is None:
+        # special-case fallback: repo URL
+        if gh_url is None:
+            logger.unchanged("No GitHub homepage or repo url found, nothing to map.")
+            return None
         logger.added(f"homepage as GitHub repo url '{gh_url}'")
         return UrlftpType(root=str(gh_url))
 
-    logger.unchanged("No GitHub homepage found, nothing to map.")
-    return bt_homepage
+    if gh_norm is None:
+        logger.unchanged("No GitHub homepage found, nothing to map.")
+        return bt_homepage
+
+    # reconciliation between GitHub homepage and bio.tools homepage
+    return reconcile_gh_over_bt(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        bt_value=bt_homepage,
+        build_bt_from_gh=lambda url: UrlftpType(root=url),
+        log_label="homepage",
+    )

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/homepage.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/homepage.py
@@ -20,26 +20,12 @@ logger = get_user_logger()
 
 def map_homepage(gh_schema: dict[str, AnyUrl | str | None], bt_homepage: UrlftpType | None) -> UrlftpType | None:
     """
-    Map and reconcile homepage metadata from GitHub and bio.tools.
+    Map and reconcile GitHub and bio.tools homepage URLs using the generic
+    GitHub-over-bio.tools policy with URL canonicalization.
 
-    Policy:
-    1. GitHub is considered the authoritative source when a homepage is present.
-       If GitHub provides a homepage (`gh_schema["homepage"]`), that value is used
-       as the canonical homepage.
-    2. bio.tools is preserved only when GitHub provides no homepage.
-       If GitHub reports no homepage (missing or ``None``), the existing bio.tools
-       homepage is returned unchanged.
-    3. Exact matches are treated as no-ops.
-       If both GitHub and bio.tools provide a homepage and their canonicalized
-       URLs are identical, the existing bio.tools value
-       is returned unchanged and an exact-match log message is emitted.
-    4. Conflicts are logged and resolved in favor of GitHub.
-       If both GitHub and bio.tools provide a homepage but the canonicalized URLs
-       differ, a conflict is logged and the GitHub homepage replaces the bio.tools
-       value.
-    5. The GitHub repository URL is used as a fallback.
-       If neither GitHub nor bio.tools provides a homepage, the GitHub repository
-       URL (`gh_schema["html_url"]`) is used as the homepage and logged as added.
+    Homepage comparison is performed on canonicalized URLs. If neither GitHub
+    nor bio.tools defines a homepage, the GitHub repository URL
+    (``gh_schema["html_url"]``) is used as a fallback.
 
     Parameters
     ----------

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
@@ -18,12 +18,40 @@ logger = get_user_logger()
 
 
 def _to_lang_set_gh(gh_languages: Language | None) -> set[str] | None:
+    """
+    Normalize the GitHub language set to a lowercased string set.
+
+    Parameters
+    ----------
+    gh_languages : Language | None
+        GitHub languages object, or ``None`` if no language data is present.
+
+    Returns
+    -------
+    set[str] | None
+        A set of lowercased language names as reported by GitHub, or ``None``
+        if GitHub provides no language data.
+    """
     if gh_languages is None or not gh_languages.root:
         return None
     return {lang.lower() for lang in gh_languages.root.keys()}
 
 
 def _to_lang_set_bt(bt_languages: list[LanguageEnum] | None) -> set[str] | None:
+    """
+    Normalize the bio.tools language list to a lowercased string set.
+
+    Parameters
+    ----------
+    bt_languages : list[LanguageEnum] | None
+        Existing bio.tools language annotations, or ``None`` if unset.
+
+    Returns
+    -------
+    set[str] | None
+        A set of lowercased language names derived from the ``LanguageEnum``
+        values, or ``None`` if no languages are recorded.
+    """
     if not bt_languages:
         return None
     return {lang.value.lower() for lang in bt_languages}
@@ -63,28 +91,13 @@ def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum] | Non
 
 def map_language(gh_languages: Language | None, bt_languages: list[LanguageEnum] | None) -> list[LanguageEnum] | None:
     """
-    Map and reconcile language metadata from GitHub and bio.tools.
+    Map and reconcile GitHub and bio.tools programming languages using the generic
+    GitHub-over-bio.tools policy.
 
-    This function compares the set of languages reported by GitHub for a
-    repository (`gh_languages`) with the existing language annotations in
-    bio.tools (`bt_languages`).
-
-    Policy:
-    1. GitHub is considered the authoritative source when present.
-       If GitHub provides a non-empty set of languages, that set is mapped to
-       `LanguageEnum` values and returned (unknown values are skipped with a log
-       message).
-    2. bio.tools is preserved only when GitHub provides no language data.
-       If GitHub reports no languages (missing or empty), the existing
-       bio.tools language annotations are returned unchanged.
-    3. Exact matches are treated as no-ops.
-       If the GitHub language set (case-insensitive) exactly matches the
-       bio.tools language set, the existing bio.tools values are returned
-       unchanged and an exact-match log message is emitted.
-    4. Conflicts are logged and resolved in favor of GitHub.
-       If both GitHub and bio.tools provide languages but they differ, a
-       conflict is logged and the GitHub-derived mapping replaces the
-       bio.tools values.
+    GitHub language keys and bio.tools ``LanguageEnum`` values are normalized to
+    lowercased string sets for comparison. When GitHub is authoritative, the
+    GitHub set is mapped back to ``LanguageEnum`` values; unknown languages are
+    skipped with a log entry.
 
     Parameters
     ----------

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
@@ -11,12 +11,25 @@ discrepancies are found.
 from bridge.core.biotools import LanguageEnum
 from bridge.core.github_languages import Language
 from bridge.logging import get_user_logger
+from bridge.pipelines.policies.gh2bt import reconcile_gh_over_bt
 from bridge.pipelines.utils import find_matching_enum_member
 
 logger = get_user_logger()
 
 
-def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum]:
+def _to_lang_set_gh(gh_languages: Language | None) -> set[str] | None:
+    if gh_languages is None or not gh_languages.root:
+        return None
+    return {lang.lower() for lang in gh_languages.root.keys()}
+
+
+def _to_lang_set_bt(bt_languages: list[LanguageEnum] | None) -> set[str] | None:
+    if not bt_languages:
+        return None
+    return {lang.value.lower() for lang in bt_languages}
+
+
+def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum] | None:
     """
     Convert a set of GitHub language names to a list of bio.tools language enums.
 
@@ -32,11 +45,12 @@ def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum]:
 
     Returns
     -------
-    list[LanguageEnum]
+    list[LanguageEnum] | None
         List of successfully mapped languages as `LanguageEnum` members.
         The order corresponds to the iteration order of the input set.
+        Returns ``None`` if no languages could be mapped.
     """
-    bt_languages = []
+    bt_languages: list[LanguageEnum] = []
     for lang in languages:
         # matched_lang = _find_matching_bt_language(lang)
         matched_lang = find_matching_enum_member(lang, LanguageEnum)
@@ -44,7 +58,7 @@ def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum]:
             bt_languages.append(matched_lang)
         else:
             logger.note(f"Unknown language '{lang}' not found in bio.tools LanguageEnum.")
-    return bt_languages
+    return bt_languages or None
 
 
 def map_language(gh_languages: Language | None, bt_languages: list[LanguageEnum] | None) -> list[LanguageEnum] | None:
@@ -86,29 +100,19 @@ def map_language(gh_languages: Language | None, bt_languages: list[LanguageEnum]
         The reconciled list of bio.tools language enums following the policy.
         May be ``None`` if both inputs are ``None``.
     """
-    if gh_languages is not None and gh_languages.root:
-        gh_languages_dict = gh_languages.root
-        gh_languages_set = set(gh_languages_dict.keys())
-    else:
-        gh_languages_set = set()
+    gh_norm = _to_lang_set_gh(gh_languages)
+    bt_norm = _to_lang_set_bt(bt_languages)
 
-    if not gh_languages_set:
+    # if GitHub has nothing, keep existing
+    if gh_norm is None or len(gh_norm) == 0:
         logger.unchanged("No GitHub languages found, nothing to map.")
         return bt_languages
 
-    gh_languages_set_lower = {lang.lower() for lang in gh_languages_set} if gh_languages_set else set()
-
-    bt_languages_set = {lang.value for lang in bt_languages} if bt_languages else set()
-    bt_languages_set_lower = {lang.lower() for lang in bt_languages_set} if bt_languages_set else set()
-
-    if gh_languages_set_lower == bt_languages_set_lower:
-        logger.exact("GitHub languages match bio.tools languages.")
-        return bt_languages
-
-    if bt_languages is not None and (gh_languages_set_lower != bt_languages_set_lower):
-        logger.conflict(
-            f"Existing GitHub languages '{gh_languages_set}'" f" differ from bio.tools languages '{bt_languages_set}'"
-        )
-
-    logger.added(f"GitHub languages '{gh_languages_set}'")
-    return _cast_to_biotools_languages(gh_languages_set)
+    # use the generic reconciler on the *set* representation
+    return reconcile_gh_over_bt(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        bt_value=bt_languages,
+        build_bt_from_gh=_cast_to_biotools_languages,
+        log_label="languages",
+    )

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
@@ -10,6 +10,7 @@ bio.tools values when GitHub is silent or ambiguous.
 
 from bridge.core.biotools import License
 from bridge.logging import get_user_logger
+from bridge.pipelines.policies.gh2bt import reconcile_gh_over_bt
 from bridge.pipelines.utils import find_matching_enum_member
 
 logger = get_user_logger()
@@ -66,16 +67,13 @@ def map_license(gh_license: str | None, bt_license: License | None) -> License |
         logger.note(f"GitHub license '{gh_license}' not recognized in bio.tools License enum, nothing to map")
         return bt_license
 
-    if bt_license is None:
-        # if no bio.tools license, return GitHub license
-        logger.added(f"license '{gh_license}'")
-        return gh_matched_license
+    gh_norm = gh_matched_license  # normalized as License enum
+    bt_norm = bt_license  # already a License enum
 
-    if bt_license != gh_matched_license:
-        # if both licenses exist, but they are not the same, return GitHub License
-        logger.conflict(f"Overwrite existing bio.tools license '{bt_license}' with GitHub license '{gh_license}'")
-        return gh_matched_license
-
-    # both licenses exist and are the same
-    logger.exact(f"license '{bt_license}'")
-    return bt_license
+    return reconcile_gh_over_bt(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        bt_value=bt_license,
+        build_bt_from_gh=lambda x: x,
+        log_label="license",
+    )

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
@@ -18,28 +18,13 @@ logger = get_user_logger()
 
 def map_license(gh_license: str | None, bt_license: License | None) -> License | None:
     """
-    Map and reconcile license metadata from GitHub and bio.tools.
+    Map and reconcile GitHub and bio.tools license annotations using the generic
+    GitHub-over-bio.tools policy.
 
-    This function aligns the GitHub license (SPDX ID) for a repository with
-    the license annotation in bio.tools, using the `License` enum as the
-    canonical representation.
-
-    Policy:
-    1. GitHub is considered authoritative when it exposes a recognized license.
-       If `gh_license` is provided and can be resolved to a `License` enum
-       member, that value is used as the canonical license.
-    2. bio.tools is preserved when GitHub is silent or unrecognized.
-       If GitHub provides no license (`gh_license is None`) or the value cannot
-       be matched to the `License` enum, the existing bio.tools license
-       (`bt_license`) is returned unchanged.
-    3. Exact matches are treated as no-ops.
-       If both GitHub and bio.tools provide a license and they resolve to the
-       same `License` enum member, the existing bio.tools value is returned
-       unchanged and an exact-match log message is emitted.
-    4. Conflicts are logged and resolved in favor of GitHub.
-       If both GitHub and bio.tools provide licenses but they resolve to
-       different `License` enum members, a conflict is logged and the
-       GitHub-derived license replaces the bio.tools value.
+    The GitHub SPDX identifier is first resolved to the ``License`` enum via
+    ``find_matching_enum_member``. Only recognized GitHub licenses participate
+    in reconciliation; unrecognized or missing GitHub values leave the existing
+    bio.tools license unchanged.
 
     Parameters
     ----------

--- a/src/bridge/pipelines/policies/__init__.py
+++ b/src/bridge/pipelines/policies/__init__.py
@@ -1,0 +1,3 @@
+"""
+Generic reconciliation policies.
+"""

--- a/src/bridge/pipelines/policies/gh2bt/__init__.py
+++ b/src/bridge/pipelines/policies/gh2bt/__init__.py
@@ -1,0 +1,7 @@
+"""
+Generic reconciliation policies for GitHub to bio.tools mapping.
+"""
+
+from .reconcile_gh_over_bt import reconcile_gh_over_bt
+
+__all__ = ["reconcile_gh_over_bt"]

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_over_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_over_bt.py
@@ -27,12 +27,51 @@ def reconcile_gh_over_bt(
     log_label: str,
 ) -> BT | None:
     """
-    Implement generic reconciliation policy function for GitHub-over-bio.tools mapping.
+    Apply a generic GitHub-over-bio.tools reconciliation policy.
 
-    - If gh_norm is None: keep bt_value.
-    - If bt_norm is None: take GitHub (build_bt_from_gh).
-    - If gh_norm == bt_norm: log exact, keep bt_value.
-    - Else: log conflict, take GitHub.
+    This function operates on *normalized* representations of GitHub and
+    bio.tools values (``gh_norm`` and ``bt_norm``), while returning and
+    constructing concrete bio.tools values (``bt_value`` and the output).
+
+    Policy:
+    1. If ``gh_norm`` is ``None``, GitHub is treated as silent and the existing
+       bio.tools value (``bt_value``) is preserved. An "unchanged" log entry is
+       emitted.
+    2. If ``gh_norm`` is not ``None`` and ``bt_norm`` is ``None``, GitHub is
+       treated as the only source. A new bio.tools value is constructed via
+       ``build_bt_from_gh(gh_norm)`` and an "added" log entry is emitted.
+    3. If both ``gh_norm`` and ``bt_norm`` are not ``None`` and they compare
+       equal (``gh_norm == bt_norm``), the existing bio.tools value
+       (``bt_value``) is preserved and an exact-match log entry is emitted.
+    4. If both ``gh_norm`` and ``bt_norm`` are not ``None`` and differ, the
+       GitHub value is treated as authoritative. A new bio.tools value is
+       constructed via ``build_bt_from_gh(gh_norm)`` and a conflict log entry
+       is emitted.
+
+    Parameters
+    ----------
+    gh_norm : GHN | None
+        Normalized representation of the GitHub value (e.g., canonicalized URL,
+        lowercased language set, enum, etc.), or ``None`` if GitHub provides no
+        usable value.
+    bt_norm : BTN | None
+        Normalized representation of the existing bio.tools value, or ``None``
+        if no value is recorded.
+    bt_value : BT | None
+        The current bio.tools value to be preserved when GitHub is silent or
+        when the normalized values match.
+    build_bt_from_gh : Callable[[GHN], BT]
+        Callable that constructs a concrete bio.tools value from the normalized
+        GitHub representation.
+    log_label : str
+        Short label used in log messages to identify the reconciled field
+        (e.g., ``"license"``, ``"languages"``, ``"homepage"``).
+
+    Returns
+    -------
+    BT | None
+        The reconciled bio.tools value according to the policy, or ``None`` if
+        both sources effectively provide no usable value.
     """
     if gh_norm is None:
         logger.unchanged(f"No GitHub {log_label} found, nothing to map.")

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_over_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_over_bt.py
@@ -1,0 +1,50 @@
+"""
+Generic reconciliation policy for GitHub-over-bio.tools mapping.
+
+This module provides a generic function to reconcile metadata between
+GitHub and bio.tools according to a defined policy that prioritizes GitHub
+values while preserving bio.tools values when GitHub is silent.
+"""
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from bridge.logging import get_user_logger
+
+logger = get_user_logger()
+
+BT = TypeVar("BT")  # bio.tools type
+GHN = TypeVar("GHN")  # normalized GitHub representation
+BTN = TypeVar("BTN")  # normalized bio.tools representation
+
+
+def reconcile_gh_over_bt(
+    *,
+    gh_norm: GHN | None,
+    bt_norm: BTN | None,
+    bt_value: BT | None,
+    build_bt_from_gh: Callable[[GHN], BT],
+    log_label: str,
+) -> BT | None:
+    """
+    Implement generic reconciliation policy function for GitHub-over-bio.tools mapping.
+
+    - If gh_norm is None: keep bt_value.
+    - If bt_norm is None: take GitHub (build_bt_from_gh).
+    - If gh_norm == bt_norm: log exact, keep bt_value.
+    - Else: log conflict, take GitHub.
+    """
+    if gh_norm is None:
+        logger.unchanged(f"No GitHub {log_label} found, nothing to map.")
+        return bt_value
+
+    if bt_norm is None:
+        logger.added(f"{log_label} from GitHub: {gh_norm!r}")
+        return build_bt_from_gh(gh_norm)
+
+    if gh_norm == bt_norm:
+        logger.exact(f"GitHub {log_label} matches bio.tools {log_label}.")
+        return bt_value
+
+    logger.conflict(f"Existing GitHub {log_label} {gh_norm!r} differs from bio.tools {log_label} {bt_norm!r}")
+    return build_bt_from_gh(gh_norm)


### PR DESCRIPTION
## Summary
Combine similar function in a simple policy: pick github over biotools when mapping github -> biotools.
Currently used by license, homepage, languages.

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER