### PR TITLE
Make documentation mapping safer, add logging

### DIFF
--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -51,7 +51,7 @@ def _add_doc_if_not_exists(
     return bt_documentation
 
 
-def map_wiki(
+def _map_wiki(
     gh_html_url: str | None, gh_has_wiki: bool | None, bt_documentation: list[DocumentationItem] | None
 ) -> list[DocumentationItem] | None:
     """
@@ -84,7 +84,7 @@ def map_wiki(
     return bt_documentation
 
 
-def map_code_of_conduct(
+def _map_code_of_conduct(
     gh_code_of_conduct: dict | None, bt_documentation: list[DocumentationItem] | None
 ) -> list[DocumentationItem] | None:
     """
@@ -114,7 +114,7 @@ def map_code_of_conduct(
     return bt_documentation
 
 
-def map_github_pages(
+def _map_github_pages(
     gh_pages: GitHubPages | None, bt_documentation: list[DocumentationItem] | None
 ) -> list[DocumentationItem] | None:
     """
@@ -185,8 +185,8 @@ def map_documentation(
     gh_code_of_conduct = gh_repo_data.get("code_of_conduct")
     gh_pages = gh_repo_data.get("github_pages")
 
-    bt_documentation = map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
-    bt_documentation = map_code_of_conduct(gh_code_of_conduct, bt_documentation)
-    bt_documentation = map_github_pages(gh_pages, bt_documentation)
+    bt_documentation = _map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
+    bt_documentation = _map_code_of_conduct(gh_code_of_conduct, bt_documentation)
+    bt_documentation = _map_github_pages(gh_pages, bt_documentation)
 
     return bt_documentation

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -1,5 +1,9 @@
 """
-Mapping functions for documentation field.
+Mapping functions for documentation metadata.
+
+This module maps GitHub repository features (wiki, code of conduct, GitHub Pages)
+to the bio.tools ``documentation`` field by adding appropriate
+``DocumentationItem`` entries when they are not already present.
 """
 
 from urllib.parse import urljoin
@@ -16,7 +20,21 @@ def _add_doc_if_not_exists(
     bt_documentation: list[DocumentationItem] | None, url: str, doc_type: TypeEnum1
 ) -> list[DocumentationItem]:
     """
-    Add documentation item if it doesn't already exist.
+    Add a documentation item for the given URL if it does not already exist.
+
+    Parameters
+    ----------
+    bt_documentation : list[DocumentationItem] | None
+        Existing bio.tools documentation list, or ``None`` if unset.
+    url : str
+        Documentation URL to add.
+    doc_type : TypeEnum1
+        Documentation type to associate with this URL.
+
+    Returns
+    -------
+    list[DocumentationItem]
+        Updated list of documentation items.
     """
     if not bt_documentation:
         bt_documentation = []
@@ -38,6 +56,24 @@ def map_wiki(
 ) -> list[DocumentationItem] | None:
     """
     Map GitHub wiki presence to bio.tools documentation.
+
+    If the repository has a wiki enabled and a repository URL is available,
+    a documentation entry of type ``TypeEnum1.General`` pointing to
+    ``<repo_url>/wiki`` is added when not already present.
+
+    Parameters
+    ----------
+    gh_html_url : str | None
+        GitHub repository HTML URL (e.g. ``https://github.com/user/repo``).
+    gh_has_wiki : bool | None
+        Flag indicating whether the repository has wiki enabled.
+    bt_documentation : list[DocumentationItem] | None
+        Existing bio.tools documentation entries.
+
+    Returns
+    -------
+    list[DocumentationItem] | None
+        Updated documentation list, or the original list if nothing changed.
     """
     if gh_has_wiki and gh_html_url:
         repo_url = str(gh_html_url)
@@ -53,6 +89,23 @@ def map_code_of_conduct(
 ) -> list[DocumentationItem] | None:
     """
     Map GitHub code of conduct presence to bio.tools documentation.
+
+    If a code of conduct is configured on GitHub and an ``html_url`` is
+    available, a documentation entry of type ``TypeEnum1.Code_of_conduct``
+    is added when not already present.
+
+    Parameters
+    ----------
+    gh_code_of_conduct : dict[str, Any] | None
+        GitHub code of conduct metadata dictionary, expected to contain
+        an ``"html_url"`` key when present.
+    bt_documentation : list[DocumentationItem] | None
+        Existing bio.tools documentation entries.
+
+    Returns
+    -------
+    list[DocumentationItem] | None
+        Updated documentation list, or the original list if nothing changed.
     """
     if gh_code_of_conduct and gh_code_of_conduct.get("html_url"):
         coc_url = gh_code_of_conduct.get("html_url")
@@ -65,7 +118,23 @@ def map_github_pages(
     gh_pages: GitHubPages | None, bt_documentation: list[DocumentationItem] | None
 ) -> list[DocumentationItem] | None:
     """
-    Map GitHub Pages to bio.tools documentation.
+    Map GitHub Pages configuration to bio.tools documentation.
+
+    If a GitHub Pages URL is configured, a documentation entry of type
+    ``TypeEnum1.General`` is added when not already present.
+
+    Parameters
+    ----------
+    gh_pages : GitHubPages | None
+        Parsed GitHub Pages information, expected to expose an ``html_url``
+        attribute when configured.
+    bt_documentation : list[DocumentationItem] | None
+        Existing bio.tools documentation entries.
+
+    Returns
+    -------
+    list[DocumentationItem] | None
+        Updated documentation list, or the original list if nothing changed.
     """
     if gh_pages and gh_pages.html_url:
         pages_url = str(gh_pages.html_url)
@@ -78,7 +147,35 @@ def map_documentation(
     gh_repo_data: dict | None, bt_documentation: list[DocumentationItem] | None
 ) -> list[DocumentationItem] | None:
     """
-    Map GitHub wiki presence to bio.tools documentation field.
+    Map and reconcile GitHub documentation-related metadata to the
+    bio.tools documentation field.
+
+    This function applies the documentation mapping policies for all
+    supported GitHub documentation sources:
+    - Repository wiki
+    - Code of conduct
+    - GitHub Pages site
+
+    Each source is mapped independently and contributes a
+    ``DocumentationItem`` entry when a corresponding URL is present on
+    GitHub and not already recorded in bio.tools.
+
+    Parameters
+    ----------
+    gh_repo_data : dict[str, Any] | None
+        GitHub repository metadata dictionary. Expected keys include:
+        - ``"html_url"``
+        - ``"has_wiki"``
+        - ``"code_of_conduct"``
+        - ``"github_pages"``
+    bt_documentation : list[DocumentationItem] | None
+        Existing bio.tools documentation entries.
+
+    Returns
+    -------
+    list[DocumentationItem] | None
+        The updated bio.tools documentation list after applying all
+        documentation mappings.
     """
     if not gh_repo_data:
         return bt_documentation

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -5,6 +5,7 @@ Mapping functions for documentation field.
 from bridge.core.biotools import DocumentationItem, TypeEnum1
 from bridge.core.github_pages import GitHubPages
 from bridge.logging import get_user_logger
+from bridge.pipelines.utils import canonicalize_url
 
 logger = get_user_logger()
 
@@ -19,9 +20,9 @@ def _add_doc_if_not_exists(
         bt_documentation = []
 
     # Normalize the incoming URL for comparison
-    normalized_url = url.rstrip("/").lower()
+    normalized_url = canonicalize_url(url)
 
-    url_exists = any(str(doc.url.root).rstrip("/").lower() == normalized_url for doc in bt_documentation)
+    url_exists = any(canonicalize_url(str(doc.url.root)) == normalized_url for doc in bt_documentation)
 
     if not url_exists:
         doc_item = DocumentationItem(url=url, type=[doc_type])
@@ -37,8 +38,8 @@ def map_wiki(
     Map GitHub wiki presence to bio.tools documentation.
     """
     if gh_has_wiki and gh_html_url:
-        repo_url = str(gh_html_url).rstrip("/")
-        wiki_url = f"{repo_url}/wiki"
+        repo_url = canonicalize_url(str(gh_html_url))
+        wiki_url = canonicalize_url(f"{repo_url}/wiki")
         return _add_doc_if_not_exists(bt_documentation, wiki_url, TypeEnum1.General)
 
     return bt_documentation

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -47,6 +47,9 @@ def _add_doc_if_not_exists(
     if not url_exists:
         doc_item = DocumentationItem(url=url, type=[doc_type])
         bt_documentation.append(doc_item)
+        logger.added(f"documentation URL '{url}' as type '{doc_type.value}'.")
+    else:
+        logger.exact(f"documentation URL '{url}' of type '{doc_type.value}' already exists, not adding.")
 
     return bt_documentation
 
@@ -81,6 +84,7 @@ def _map_wiki(
         wiki_url = canonicalize_url(wiki_raw)
         return _add_doc_if_not_exists(bt_documentation, wiki_url, TypeEnum1.General)
 
+    logger.unchanged("no GitHub wiki found, nothing to map.")
     return bt_documentation
 
 
@@ -111,6 +115,7 @@ def _map_code_of_conduct(
         coc_url = gh_code_of_conduct.get("html_url")
         return _add_doc_if_not_exists(bt_documentation, coc_url, TypeEnum1.Code_of_conduct)
 
+    logger.unchanged("no GitHub code of conduct found, nothing to map.")
     return bt_documentation
 
 
@@ -140,6 +145,7 @@ def _map_github_pages(
         pages_url = str(gh_pages.html_url)
         return _add_doc_if_not_exists(bt_documentation, pages_url, TypeEnum1.General)
 
+    logger.unchanged("no GitHub Pages site found, nothing to map.")
     return bt_documentation
 
 
@@ -178,6 +184,7 @@ def map_documentation(
         documentation mappings.
     """
     if not gh_repo_data:
+        logger.unchanged("no GitHub repository documentation data found, nothing to map.")
         return bt_documentation
 
     gh_html_url = gh_repo_data.get("html_url")

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -2,6 +2,8 @@
 Mapping functions for documentation field.
 """
 
+from urllib.parse import urljoin
+
 from bridge.core.biotools import DocumentationItem, TypeEnum1
 from bridge.core.github_pages import GitHubPages
 from bridge.logging import get_user_logger
@@ -38,8 +40,9 @@ def map_wiki(
     Map GitHub wiki presence to bio.tools documentation.
     """
     if gh_has_wiki and gh_html_url:
-        repo_url = canonicalize_url(str(gh_html_url))
-        wiki_url = canonicalize_url(f"{repo_url}/wiki")
+        repo_url = str(gh_html_url)
+        wiki_raw = urljoin(repo_url.rstrip("/") + "/", "wiki")
+        wiki_url = canonicalize_url(wiki_raw)
         return _add_doc_if_not_exists(bt_documentation, wiki_url, TypeEnum1.General)
 
     return bt_documentation

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/documentation.py
@@ -4,8 +4,9 @@ Mapping functions for documentation field.
 
 from bridge.core.biotools import DocumentationItem, TypeEnum1
 from bridge.core.github_pages import GitHubPages
+from bridge.logging import get_user_logger
 
-# TODO: add logging
+logger = get_user_logger()
 
 
 def _add_doc_if_not_exists(

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_documentation.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_documentation.py
@@ -6,10 +6,10 @@ from bridge.core.biotools import DocumentationItem, TypeEnum1
 from bridge.core.github_pages import GitHubPages
 from bridge.pipelines.gh2bt_for_meta.map_funcs.documentation import (
     _add_doc_if_not_exists,
-    map_code_of_conduct,
+    _map_code_of_conduct,
+    _map_github_pages,
+    _map_wiki,
     map_documentation,
-    map_github_pages,
-    map_wiki,
 )
 
 
@@ -22,7 +22,7 @@ class TestMapWiki:
         gh_has_wiki = True
         bt_documentation = None
 
-        result = map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
+        result = _map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
 
         assert result is not None
         assert len(result) == 1
@@ -35,7 +35,7 @@ class TestMapWiki:
         gh_has_wiki = False
         bt_documentation = None
 
-        result = map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
+        result = _map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
 
         assert result is None
 
@@ -45,7 +45,7 @@ class TestMapWiki:
         gh_has_wiki = True
         bt_documentation = None
 
-        result = map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
+        result = _map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
 
         assert result is None
 
@@ -57,7 +57,7 @@ class TestMapWiki:
         existing_doc = DocumentationItem(url="https://github.com/owner/repo/wiki", type=[TypeEnum1.General])
         bt_documentation = [existing_doc]
 
-        result = map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
+        result = _map_wiki(gh_html_url, gh_has_wiki, bt_documentation)
 
         assert result is not None
         assert len(result) == 1  # Should still be 1, not 2
@@ -71,7 +71,7 @@ class TestMapCodeOfConduct:
         gh_code_of_conduct = {"html_url": "https://github.com/owner/repo/blob/main/CODE_OF_CONDUCT.md"}
         bt_documentation = None
 
-        result = map_code_of_conduct(gh_code_of_conduct, bt_documentation)
+        result = _map_code_of_conduct(gh_code_of_conduct, bt_documentation)
 
         assert result is not None
         assert len(result) == 1
@@ -83,7 +83,7 @@ class TestMapCodeOfConduct:
         gh_code_of_conduct = None
         bt_documentation = None
 
-        result = map_code_of_conduct(gh_code_of_conduct, bt_documentation)
+        result = _map_code_of_conduct(gh_code_of_conduct, bt_documentation)
 
         assert result is None
 
@@ -92,7 +92,7 @@ class TestMapCodeOfConduct:
         gh_code_of_conduct = {}
         bt_documentation = None
 
-        result = map_code_of_conduct(gh_code_of_conduct, bt_documentation)
+        result = _map_code_of_conduct(gh_code_of_conduct, bt_documentation)
 
         assert result is None
 
@@ -105,7 +105,7 @@ class TestMapCodeOfConduct:
         )
         bt_documentation = [existing_doc]
 
-        result = map_code_of_conduct(gh_code_of_conduct, bt_documentation)
+        result = _map_code_of_conduct(gh_code_of_conduct, bt_documentation)
 
         assert result is not None
         assert len(result) == 1  # Should still be 1, not 2
@@ -126,7 +126,7 @@ class TestMapGitHubPages:
         )
         bt_documentation = None
 
-        result = map_github_pages(gh_pages, bt_documentation)
+        result = _map_github_pages(gh_pages, bt_documentation)
 
         assert result is not None
         assert len(result) == 1
@@ -145,7 +145,7 @@ class TestMapGitHubPages:
         )
         bt_documentation = None
 
-        result = map_github_pages(gh_pages, bt_documentation)
+        result = _map_github_pages(gh_pages, bt_documentation)
 
         assert result is not None
         assert len(result) == 1
@@ -156,7 +156,7 @@ class TestMapGitHubPages:
         gh_pages = None
         bt_documentation = None
 
-        result = map_github_pages(gh_pages, bt_documentation)
+        result = _map_github_pages(gh_pages, bt_documentation)
 
         assert result is None
 
@@ -172,7 +172,7 @@ class TestMapGitHubPages:
         )
         bt_documentation = None
 
-        result = map_github_pages(gh_pages, bt_documentation)
+        result = _map_github_pages(gh_pages, bt_documentation)
 
         assert result is None
 
@@ -189,7 +189,7 @@ class TestMapGitHubPages:
         existing_doc = DocumentationItem(url="https://owner.github.io/repo", type=[TypeEnum1.General])
         bt_documentation = [existing_doc]
 
-        result = map_github_pages(gh_pages, bt_documentation)
+        result = _map_github_pages(gh_pages, bt_documentation)
 
         assert result is not None
         assert len(result) == 1  # Should still be 1, not 2


### PR DESCRIPTION
## Summary
Make documentation mapping safer gh->bt, add logging

## Type
- [ ] feat
- [x] fix
- [x] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER