### PR TITLE
Combine similar functions in a simple policy bt->gh

### DIFF
--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -1,9 +1,12 @@
 """
-Mapping functions for description metadata.
+Map description metadata from bio.tools to GitHub.
 
-This module compares a repository's existing GitHub
-description with the description registered in bio.tools, and, when useful,
-propose a GitHub issue suggesting that the bio.tools description be adopted.
+This module compares the description recorded in bio.tools with the
+description configured on a GitHub repository and, when appropriate,
+proposes a GitHub issue suggesting that the bio.tools description be
+adopted. It applies a bio.tools-over-GitHub policy that only suggests
+changes when bio.tools provides a description and the repository has
+no conflicting description set.
 """
 
 from bridge.logging import get_user_logger
@@ -15,20 +18,14 @@ logger = get_user_logger()
 
 def map_description(gh_description: str | None, bt_description: str | None) -> dict[str, str] | None:
     """
-    Propose a GitHub issue to add a description based on bio.tools metadata.
+    Propose a GitHub issue to add a description based on bio.tools metadata,
+    using the generic bio.tools-over-GitHub issue policy.
 
-    This function examines the description from a bio.tools entry and the
-    current description of a GitHub repository. It decides whether it makes
-    sense to open an issue suggesting that the bio.tools description be added
-    to the repository.
-
-    Decision logic:
-    1. If `bt_description` (bio.tools description) is missing, nothing to do.
-    2. If `bt_description` is identical to the GitHub description, nothing to do.
-    3. If the repository already has a description that differs from
-       `bt_description`, log a conflict and do not propose an issue.
-    4. If the repository has no description set and `bt_description` is present,
-       propose an issue suggesting that it be added.
+    Both the GitHub and bio.tools descriptions are normalized (HTML/whitespace
+    cleanup) before comparison. A suggestion is only made when bio.tools
+    provides a description and the GitHub repository has no description set;
+    existing, differing GitHub descriptions are treated as authoritative and
+    result in a logged conflict but no proposed issue.
 
     Parameters
     ----------
@@ -43,7 +40,7 @@ def map_description(gh_description: str | None, bt_description: str | None) -> d
     -------
     dict[str, str] | None
         A mapping with the issue title as key and the issue body as value,
-        or ``None`` if no issue is to be created.
+        or ``None`` if no issue is to be created under the policy.
     """
     gh_norm = normalize_text(gh_description)
     bt_norm = normalize_text(bt_description)

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -10,7 +10,7 @@ no conflicting description set.
 """
 
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies import reconcile_bt_over_gh_issue
+from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh_issue
 from bridge.pipelines.utils import normalize_text
 
 logger = get_user_logger()

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -7,6 +7,8 @@ propose a GitHub issue suggesting that the bio.tools description be adopted.
 """
 
 from bridge.logging import get_user_logger
+from bridge.pipelines.policies import reconcile_bt_over_gh_issue
+from bridge.pipelines.utils import normalize_text
 
 logger = get_user_logger()
 
@@ -43,23 +45,20 @@ def map_description(gh_description: str | None, bt_description: str | None) -> d
         A mapping with the issue title as key and the issue body as value,
         or ``None`` if no issue is to be created.
     """
-    if bt_description is None:
-        # if there is no bio.tools description, no need for the issue
-        logger.note("bio.tools description is None, nothing to map.")
-        return None
+    gh_norm = normalize_text(gh_description)
+    bt_norm = normalize_text(bt_description)
 
-    if bt_description == gh_description:
-        logger.exact("bio.tools description is the same as GitHub description, no need to map.")
-        return None
+    def make_issue(desc: str) -> dict[str, str]:
+        return {
+            "Add description from bio.tools metadata": (
+                f"The bio.tools description is:\n\n{desc}\n\n"
+                "Please consider adding this description to the GitHub repository."
+            )
+        }
 
-    if gh_description is not None:
-        logger.conflict("existing GitHub description differs from bio.tools description")
-        return None
-
-    logger.added(f"description: '{bt_description}'")
-    return {
-        "Add description from bio.tools metadata": (
-            f"The bio.tools description is:\n\n{bt_description}\n\n"
-            "Please consider adding this description to the GitHub repository."
-        )
-    }
+    return reconcile_bt_over_gh_issue(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        make_issue=make_issue,
+        log_label="description",
+    )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -13,7 +13,7 @@ from pydantic import AnyUrl
 
 from bridge.core.biotools import UrlftpType
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies import reconcile_bt_over_gh_issue
+from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh_issue
 from bridge.pipelines.utils import canonicalize_url
 
 logger = get_user_logger()

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -14,6 +14,7 @@ from pydantic import AnyUrl
 from bridge.core.biotools import UrlftpType
 from bridge.logging import get_user_logger
 from bridge.pipelines.policies import reconcile_bt_over_gh_issue
+from bridge.pipelines.utils import canonicalize_url
 
 logger = get_user_logger()
 
@@ -23,11 +24,12 @@ def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType |
     Propose a GitHub issue to add a homepage based on bio.tools metadata,
     using the generic bio.tools-over-GitHub issue policy.
 
-    The GitHub homepage and bio.tools homepage are normalized by stripping
-    trailing slashes before comparison. If the bio.tools homepage is equal
-    to the repository HTML URL, no suggestion is made. If GitHub already
-    has a different homepage configured, that value is treated as
-    authoritative and a conflict is logged without proposing an issue.
+    All URLs (GitHub homepage, GitHub HTML URL, and bio.tools homepage)
+    are compared in canonicalized form to avoid spurious differences due
+    to trailing slashes, case, or query parameter ordering.
+    If the bio.tools homepage is equal to the repository HTML URL,
+    no suggestion is made. If GitHub already has a different homepage configured, t
+    hat value is treated as authoritative and a conflict is logged without proposing an issue.
     Only when the bio.tools homepage is present, differs from the HTML URL,
     and the GitHub homepage is unset does this function propose an issue.
 
@@ -48,26 +50,31 @@ def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType |
         A mapping with the issue title as key and the issue body as value,
         or ``None`` if no issue is to be created.
     """
-    gt_homepage = gh_schema.get("homepage")
-    gh_hp = str(gt_homepage).rstrip("/") if gt_homepage else None
-    gh_url = str(gh_schema["html_url"]).rstrip("/")
-    bt_hp = str(bt_homepage).rstrip("/") if bt_homepage else None
+    gh_homepage_raw = gh_schema.get("homepage")
+    gh_url_raw = gh_schema.get("html_url")
+    bt_homepage_raw = str(bt_homepage.root) if bt_homepage is not None else None
 
-    if bt_hp is not None and bt_hp == gh_url:
-        logger.exact("bio.tools homepage is the same as GitHub URL, no need to map.")
+    gh_hp_norm = canonicalize_url(str(gh_homepage_raw)) if gh_homepage_raw else None
+    gh_url_norm = canonicalize_url(str(gh_url_raw)) if gh_url_raw else None
+    bt_hp_norm = canonicalize_url(bt_homepage_raw) if bt_homepage_raw else None
+
+    if bt_hp_norm is not None and gh_url_norm is not None and bt_hp_norm == gh_url_norm:
+        logger.exact("bio.tools homepage is the same as GitHub repository URL, no need to map.")
         return None
 
-    def make_issue(homepage: str) -> dict[str, str]:
+    def make_issue(homepage_norm: str) -> dict[str, str]:
+        # Use the normalized value for the suggestion; if you prefer the raw value,
+        # you can pass `bt_homepage_raw` instead.
         return {
             "Add homepage from bio.tools metadata": (
-                f"The bio.tools homepage is:\n\n{homepage}\n\n"
+                f"The bio.tools homepage is:\n\n{homepage_norm}\n\n"
                 "Please consider adding this homepage to the GitHub repository."
             )
         }
 
     return reconcile_bt_over_gh_issue(
-        gh_norm=gh_hp,
-        bt_norm=bt_hp,
+        gh_norm=gh_hp_norm,
+        bt_norm=bt_hp_norm,
         make_issue=make_issue,
         log_label="homepage",
     )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -10,6 +10,7 @@ from pydantic import AnyUrl
 
 from bridge.core.biotools import UrlftpType
 from bridge.logging import get_user_logger
+from bridge.pipelines.policies import reconcile_bt_over_gh_issue
 
 logger = get_user_logger()
 
@@ -51,26 +52,24 @@ def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType |
     """
     gt_homepage = gh_schema.get("homepage")
     gh_hp = str(gt_homepage).rstrip("/") if gt_homepage else None
-    gh_url = gh_schema["html_url"]
+    gh_url = str(gh_schema["html_url"]).rstrip("/")
     bt_hp = str(bt_homepage).rstrip("/") if bt_homepage else None
 
-    if bt_hp is None:
-        logger.note("bio.tools homepage is None, nothing to map.")
-        return None
-
-    if bt_hp == gh_url:
+    if bt_hp is not None and bt_hp == gh_url:
         logger.exact("bio.tools homepage is the same as GitHub URL, no need to map.")
         return None
 
-    if gh_hp is not None:
-        if gh_hp != bt_hp:
-            logger.conflict(f"existing GitHub homepage '{gh_hp}' differs from bio.tools homepage '{bt_hp}'")
-            return None
+    def make_issue(homepage: str) -> dict[str, str]:
+        return {
+            "Add homepage from bio.tools metadata": (
+                f"The bio.tools homepage is:\n\n{homepage}\n\n"
+                "Please consider adding this homepage to the GitHub repository."
+            )
+        }
 
-    logger.added(f"homepage '{bt_hp}'")
-    return {
-        "Add homepage from bio.tools metadata": (
-            f"The bio.tools homepage is:\n\n{bt_hp}\n\n"
-            "Please consider adding this homepage to the GitHub repository."
-        )
-    }
+    return reconcile_bt_over_gh_issue(
+        gh_norm=gh_hp,
+        bt_norm=bt_hp,
+        make_issue=make_issue,
+        log_label="homepage",
+    )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -1,9 +1,12 @@
 """
-Map homepage URL from bio.tools metadata to a GitHub repository.
+Map homepage URL from bio.tools to a GitHub.
 
-This module compares the homepage URL recorded in bio.tools with the homepage
-(and HTML URL) of a GitHub repository, and decides whether an issue should be
-opened to suggest updating the repository's homepage.
+This module compares the homepage URL recorded in bio.tools with the
+homepage (and HTML URL) of a GitHub repository and, when appropriate,
+proposes a GitHub issue suggesting that the bio.tools homepage be added
+to the repository settings. It applies a bio.tools-over-GitHub policy:
+bio.tools is only used to suggest a homepage when GitHub has no
+conflicting homepage configured.
 """
 
 from pydantic import AnyUrl
@@ -17,21 +20,16 @@ logger = get_user_logger()
 
 def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType | None) -> dict[str, str] | None:
     """
-    Propose a GitHub issue to add a homepage based on bio.tools metadata.
+    Propose a GitHub issue to add a homepage based on bio.tools metadata,
+    using the generic bio.tools-over-GitHub issue policy.
 
-    This function examines the homepage URL from bio.tools and the existing
-    homepage/HTML URL of a GitHub repository and decides whether it makes
-    sense to open an issue suggesting the addition of the bio.tools homepage
-    to the repository settings.
-
-    Decision logic:
-    1. If `bt_homepage` (bio.tools homepage) is missing, nothing to do.
-    2. If `bt_homepage` is the same as the repository's HTML URL
-       (e.g. https://github.com/org/repo), nothing to do.
-    3. If the repository already has a homepage set and it differs from
-       `bt_homepage`, log a conflict and do not propose an issue.
-    4. If the repository has no homepage set and `bt_homepage` is present
-       and different from the HTML URL, propose an issue to add it.
+    The GitHub homepage and bio.tools homepage are normalized by stripping
+    trailing slashes before comparison. If the bio.tools homepage is equal
+    to the repository HTML URL, no suggestion is made. If GitHub already
+    has a different homepage configured, that value is treated as
+    authoritative and a conflict is logged without proposing an issue.
+    Only when the bio.tools homepage is present, differs from the HTML URL,
+    and the GitHub homepage is unset does this function propose an issue.
 
     Parameters
     ----------

--- a/src/bridge/pipelines/policies/bt2gh/__init__.py
+++ b/src/bridge/pipelines/policies/bt2gh/__init__.py
@@ -1,0 +1,7 @@
+"""
+Generic reconciliation policies for bio.tools to GitHub mapping.
+"""
+
+from .reconcile_bt_over_gh import reconcile_bt_over_gh_issue
+
+__all__ = ["reconcile_bt_over_gh_issue"]

--- a/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
+++ b/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
@@ -1,0 +1,85 @@
+"""
+Generic reconciliation policies for bio.tools to GitHub mapping.
+
+This module provides a generic function to determine whether a GitHub issue
+should be proposed based on bio.tools metadata, according to a policy that
+treats bio.tools as authoritative while preserving existing GitHub values
+when bio.tools is silent.
+"""
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from bridge.logging import get_user_logger
+
+logger = get_user_logger()
+
+BTN = TypeVar("BTN")  # normalized bio.tools representation
+GHN = TypeVar("GHN")  # normalized GitHub representation
+ISSUE = TypeVar("ISSUE")  # issue payload type, e.g. dict[str, str]
+
+
+def reconcile_bt_over_gh_issue(
+    *,
+    gh_norm: GHN | None,
+    bt_norm: BTN | None,
+    make_issue: Callable[[BTN], ISSUE],
+    log_label: str,
+) -> ISSUE | None:
+    """
+    Apply a generic bio.tools-over-GitHub policy to decide whether to
+    propose a GitHub issue based on bio.tools metadata.
+
+    This function operates on *normalized* representations of GitHub and
+    bio.tools values (``gh_norm`` and ``bt_norm``) and returns an issue
+    payload constructed from the bio.tools value when applicable.
+
+    Policy:
+    1. If ``bt_norm`` is ``None``, bio.tools is treated as silent and no
+       issue is proposed. An "unchanged" log entry is emitted.
+    2. If ``gh_norm`` is not ``None`` and equals ``bt_norm``, the values
+       are considered aligned and no issue is proposed.
+       An "exact" log entry is emitted.
+    3. If ``gh_norm`` is not ``None`` and differs from ``bt_norm``, GitHub
+       is treated as conflicting with bio.tools. A conflict log entry is
+       emitted and an issue proposing the bio.tools value is constructed
+       via ``make_issue(bt_norm)``.
+    4. If ``gh_norm`` is ``None`` and ``bt_norm`` is not ``None``, GitHub
+       is missing the value and an issue proposing the bio.tools value is
+       constructed via ``make_issue(bt_norm)`` with an added log entry.
+
+    Parameters
+    ----------
+    gh_norm : GHN | None
+        Normalized representation of the GitHub value, or ``None`` if no
+        usable value is available from GitHub.
+    bt_norm : BTN | None
+        Normalized representation of the bio.tools value, or ``None`` if
+        no value is recorded in bio.tools.
+    make_issue : Callable[[BTN], ISSUE]
+        Callable that constructs an issue payload from the normalized
+        bio.tools value.
+    log_label : str
+        Short label used in log messages to identify the metadata field
+        (e.g., ``"description"``, ``"homepage"``, ``"license"``).
+
+    Returns
+    -------
+    ISSUE | None
+        Issue payload to propose according to the policy, or ``None`` if
+        no issue should be created.
+    """
+    if bt_norm is None:
+        logger.unchanged(f"No bio.tools {log_label} found, nothing to map.")
+        return None
+
+    if gh_norm is not None:
+        if gh_norm == bt_norm:
+            logger.exact(f"bio.tools {log_label} matches GitHub {log_label}, no need to map.")
+            return None
+
+        logger.conflict(f"existing GitHub {log_label} {gh_norm!r} differs from bio.tools {log_label} {bt_norm!r}")
+        return make_issue(bt_norm)
+
+    logger.added(f"{log_label}: {bt_norm!r}")
+    return make_issue(bt_norm)


### PR DESCRIPTION
## Summary
Combine similar functions in a simple policy: pick biotools over GitHub when mapping biotools -> GitHub.
Currently used by description and homepage.
Also make homepage a bit safer.

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER