### PR TITLE
Map license bt->gt + policy updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ GITHUB_TOKEN=ghp_xxx
 GITHUB_API_URL=https://api.github.com
 
 # bio.tools
-BIOTOOLS_URL="https://bio.tools/"
+BIOTOOLS_URL=https://bio.tools/
 BIOTOOLS_API_URL=https://bio.tools/api
 
 # Hugging Face
@@ -14,3 +14,6 @@ HUGGINGFACE_API_URL=https://router.huggingface.co/hf-inference
 
 # Europe PMC
 EUROPE_PMC_API_URL=https://www.ebi.ac.uk/europepmc/webservices/rest
+
+# SPDX
+SPDX_LICENSE_BASE_URL=https://spdx.org/licenses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ force-exclude = '''
   | (^|/)src/bridge/core/github_repo\\.py
   | (^|/)src/bridge/core/github_latest_release\\.py
   | (^|/)src/bridge/core/github_languages\\.py
+  | (^|/)src/bridge/core/spdx\\.py
   | (^|/)docs/
 )
 """
@@ -68,6 +69,7 @@ extend-exclude = [
   "src/bridge/core/github_repo.py",
   "src/bridge/core/github_latest_release.py",
   "src/bridge/core/github_languages.py",
+  "src/bridge/core/spdx.py",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ force-exclude = '''
   | (^|/)src/bridge/core/github_repo\\.py
   | (^|/)src/bridge/core/github_latest_release\\.py
   | (^|/)src/bridge/core/github_languages\\.py
-  | (^|/)src/bridge/core/spdx\\.py
+  | (^|/)src/bridge/core/license\\.py
   | (^|/)docs/
 )
 """
@@ -69,7 +69,7 @@ extend-exclude = [
   "src/bridge/core/github_repo.py",
   "src/bridge/core/github_latest_release.py",
   "src/bridge/core/github_languages.py",
-  "src/bridge/core/spdx.py",
+  "src/bridge/core/license.py",
 ]
 
 [tool.ruff.lint]

--- a/src/bridge/builders/__init__.py
+++ b/src/bridge/builders/__init__.py
@@ -5,9 +5,11 @@ Builders assemble core models from raw ingested data.
 from .biotools import compose_biotools_metadata
 from .europe_pmc import compose_europe_pmc_metadata
 from .github import compose_github_repo
+from .spdx import compose_spdx_license_metadata
 
 __all__ = [
     "compose_github_repo",
     "compose_biotools_metadata",
     "compose_europe_pmc_metadata",
+    "compose_spdx_license_metadata",
 ]

--- a/src/bridge/builders/spdx/__init__.py
+++ b/src/bridge/builders/spdx/__init__.py
@@ -1,0 +1,7 @@
+"""
+Composition utilities for SPDX: fetch raw license JSON and transform it into a validated SPDXLicense model.
+"""
+
+from .spdx_composer import compose_spdx_license_metadata
+
+__all__ = ["compose_spdx_license_metadata"]

--- a/src/bridge/builders/spdx/spdx_composer.py
+++ b/src/bridge/builders/spdx/spdx_composer.py
@@ -1,0 +1,44 @@
+"""
+High-level coroutine that chains EuropePMCIngestor and EuropePMCTransformer
+to produce a Publication model from a Europe PMC ID.
+"""
+
+import logging
+
+from bridge.core import SPDXLicense
+from bridge.services import SPDXLicenseIngestor
+
+from .spdx_transormer import SPDXLicenseTransformer
+
+logger = logging.getLogger(__name__)
+
+
+async def compose_spdx_license_metadata(spdx_id: str) -> SPDXLicense:
+    """
+    Fetch and transform SPDX license entry into a SPDXLicense model.
+
+    Parameters
+    ----------
+    spdx_id : str
+        SPDX license identifier (e.g. "MIT", "GPL-3.0-only").
+
+    Returns
+    -------
+    SPDXLicense
+        A SPDXLicense model representing the SPDX license metadata.
+
+    Raises
+    ------
+    Exception
+        If there is an error during ingestion or transformation.
+    """
+    logger.info(f"Composing SPDX license metadata model for ID {spdx_id}")
+    try:
+        spdx_license_ingestor = SPDXLicenseIngestor(spdx_id=spdx_id)
+        spdx_license_transformer = SPDXLicenseTransformer(spdx_license_ingestor)
+        spdx_license_metadata = await spdx_license_transformer.transform()
+        logger.info(f"Composed SPDX license metadata model for ID {spdx_id} successfully")
+        return spdx_license_metadata
+    except Exception as e:
+        logger.exception(f"Error composing SPDX license metadata model for ID {spdx_id}: {e}")
+        raise

--- a/src/bridge/builders/spdx/spdx_transormer.py
+++ b/src/bridge/builders/spdx/spdx_transormer.py
@@ -1,0 +1,46 @@
+"""
+Transformer converting raw SPDX license data into a SPDXLicenseModel.
+"""
+
+import logging
+
+from bridge.builders.protocols import Transformer
+from bridge.core.license import SPDXLicenseModel
+from bridge.services import SPDXLicenseIngestor
+
+logger = logging.getLogger(__name__)
+
+
+class SPDXLicenseTransformer(Transformer):
+    """
+    Transform raw data from SPDXLicenseIngestor into a SPDXLicenseModel.
+
+    Parameters
+    ----------
+    ingestor : SPDXLicenseIngestor
+        An instance of SPDXLicenseIngestor to fetch raw license metadata.
+
+    Attributes
+    ----------
+    ingestor : SPDXLicenseIngestor
+        The ingestor instance used to fetch raw license metadata.
+    """
+
+    def __init__(self, ingestor: SPDXLicenseIngestor):
+        self.ingestor = ingestor
+
+    async def transform(self) -> SPDXLicenseModel:
+        """
+        Transform raw data into a SPDXLicenseModel.
+
+        Returns
+        -------
+        SPDXLicenseModel
+            The transformed license model.
+        """
+        logger.info(f"Transforming data for SPDX license ID {self.ingestor.spdx_id}")
+        raw_data = await self.ingestor.fetch()
+        logger.debug(f"Raw data keys: {list(raw_data.keys())}")
+        result = SPDXLicenseModel(**raw_data)
+        logger.info(f"Transformed data for SPDX license ID {self.ingestor.spdx_id} successfully")
+        return result

--- a/src/bridge/builders/spdx/spdx_transormer.py
+++ b/src/bridge/builders/spdx/spdx_transormer.py
@@ -1,11 +1,11 @@
 """
-Transformer converting raw SPDX license data into a SPDXLicenseModel.
+Transformer converting raw SPDX license data into a SPDXLicense.
 """
 
 import logging
 
 from bridge.builders.protocols import Transformer
-from bridge.core.license import SPDXLicenseModel
+from bridge.core.license import SPDXLicense
 from bridge.services import SPDXLicenseIngestor
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class SPDXLicenseTransformer(Transformer):
     """
-    Transform raw data from SPDXLicenseIngestor into a SPDXLicenseModel.
+    Transform raw data from SPDXLicenseIngestor into a SPDXLicense.
 
     Parameters
     ----------
@@ -29,18 +29,18 @@ class SPDXLicenseTransformer(Transformer):
     def __init__(self, ingestor: SPDXLicenseIngestor):
         self.ingestor = ingestor
 
-    async def transform(self) -> SPDXLicenseModel:
+    async def transform(self) -> SPDXLicense:
         """
-        Transform raw data into a SPDXLicenseModel.
+        Transform raw data into a SPDXLicense.
 
         Returns
         -------
-        SPDXLicenseModel
+        SPDXLicense
             The transformed license model.
         """
         logger.info(f"Transforming data for SPDX license ID {self.ingestor.spdx_id}")
         raw_data = await self.ingestor.fetch()
         logger.debug(f"Raw data keys: {list(raw_data.keys())}")
-        result = SPDXLicenseModel(**raw_data)
+        result = SPDXLicense(**raw_data)
         logger.info(f"Transformed data for SPDX license ID {self.ingestor.spdx_id} successfully")
         return result

--- a/src/bridge/config.py
+++ b/src/bridge/config.py
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     # Europe PMC
     europe_pmc_api_url: HttpUrl = "https://www.ebi.ac.uk/europepmc/webservices/rest"
 
+    # SPDX license list
+    spdx_license_base_url: HttpUrl = "https://spdx.org/licenses"
+
     # Logging
     log_level: str = "INFO"
 
@@ -50,6 +53,11 @@ class Settings(BaseSettings):
     def europepmc_api_base(self) -> str:
         """Base URL for Europe PMC API as a string"""
         return self._api_base(self.europe_pmc_api_url)
+
+    @property
+    def spdx_license_base(self) -> str:
+        """Base URL for SPDX license JSON as a string"""
+        return self._api_base(self.spdx_license_base_url)
 
     @staticmethod
     def _api_base(url: HttpUrl) -> str:

--- a/src/bridge/core/__init__.py
+++ b/src/bridge/core/__init__.py
@@ -5,10 +5,12 @@ Re-exports validated Pydantic models for repositories and metadata.
 
 from .biotools import ToolModel as BiotoolsToolModel
 from .github import GitHubRepoModel
+from .license import SPDXLicense
 from .publication import Publication
 
 __all__ = [
     "BiotoolsToolModel",
     "GitHubRepoModel",
     "Publication",
+    "SPDXLicense",
 ]

--- a/src/bridge/core/license.py
+++ b/src/bridge/core/license.py
@@ -33,7 +33,7 @@ class SPDXCrossRef(BaseModel):
     timestamp: str | None = None
 
 
-class SPDXLicenseModel(BaseModel):
+class SPDXLicense(BaseModel):
     """
     Represent an SPDX license.
 

--- a/src/bridge/core/license.py
+++ b/src/bridge/core/license.py
@@ -2,7 +2,7 @@
 Module defining the SPDX license data model.
 """
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 
 class SPDXCrossRef(BaseModel):
@@ -23,7 +23,13 @@ class SPDXCrossRef(BaseModel):
         The match type of the cross-reference.
     timestamp : str | None
         The timestamp of the cross-reference.
+    order : int | None
+        The order of the cross-reference.
     """
+
+    model_config = ConfigDict(
+        extra="ignore",
+    )
 
     url: HttpUrl
     isValid: bool | None = None
@@ -31,6 +37,7 @@ class SPDXCrossRef(BaseModel):
     isWayBackLink: bool | None = None
     match_: str | None = Field(default=None, alias="match")
     timestamp: str | None = None
+    order: int | None = None
 
 
 class SPDXLicense(BaseModel):
@@ -45,28 +52,35 @@ class SPDXLicense(BaseModel):
         Full name of the license.
     licenseText : str
         Canonical license text.
+    licenseTextHtml : str
+        HTML-formatted license text.
+    isDeprecatedLicenseId : bool | None
+        Whether the license ID is deprecated.
+    standardLicenseTemplate : str | None
+        Standard license template text, if available.
     isOsiApproved : bool | None
-        Whether the license is OSI approved.
+        Whether the license is OSI-approved.
     isFsfLibre : bool | None
         Whether the license is FSF libre.
-    standardLicenseHeader : str | None
-        Standard license header text, if available.
-    licenseComments : str | None
-        Additional comments about the license.
     seeAlso : list[HttpUrl] | None
-        List of URLs with more information about the license.
+        List of URLs with additional information about the license.
     crossRef : list[SPDXCrossRef] | None
         List of cross-references for the license.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+    )
+
     licenseId: str
     name: str
     licenseText: str
+    licenseTextHtml: str
 
+    isDeprecatedLicenseId: bool | None = None
+    standardLicenseTemplate: str | None = None
     isOsiApproved: bool | None = None
     isFsfLibre: bool | None = None
-    standardLicenseHeader: str | None = None
-    licenseComments: str | None = None
 
     seeAlso: list[HttpUrl] | None = None
     crossRef: list[SPDXCrossRef] | None = None

--- a/src/bridge/core/spdx.py
+++ b/src/bridge/core/spdx.py
@@ -1,0 +1,72 @@
+"""
+Module defining the SPDX license data model.
+"""
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class SPDXCrossRef(BaseModel):
+    """
+    Represent a cross-reference for an SPDX license.
+
+    Parameters
+    ----------
+    url : HttpUrl
+        The URL of the cross-reference.
+    isValid : bool | None
+        Whether the cross-reference is valid.
+    isLive : bool | None
+        Whether the cross-reference is live.
+    isWayBackLink : bool | None
+        Whether the cross-reference is a Wayback Machine link.
+    match_ : str | None
+        The match type of the cross-reference.
+    timestamp : str | None
+        The timestamp of the cross-reference.
+    """
+
+    url: HttpUrl
+    isValid: bool | None = None
+    isLive: bool | None = None
+    isWayBackLink: bool | None = None
+    match_: str | None = Field(default=None, alias="match")
+    timestamp: str | None = None
+
+
+class SPDXLicenseModel(BaseModel):
+    """
+    Represent an SPDX license.
+
+    Parameters
+    ----------
+    licenseId : str
+        SPDX license identifier (e.g. ``"MIT"``, ``"GPL-3.0-only"``).
+    name : str
+        Full name of the license.
+    licenseText : str
+        Canonical license text.
+    isOsiApproved : bool | None
+        Whether the license is OSI approved.
+    isFsfLibre : bool | None
+        Whether the license is FSF libre.
+    standardLicenseHeader : str | None
+        Standard license header text, if available.
+    licenseComments : str | None
+        Additional comments about the license.
+    seeAlso : list[HttpUrl] | None
+        List of URLs with more information about the license.
+    crossRef : list[SPDXCrossRef] | None
+        List of cross-references for the license.
+    """
+
+    licenseId: str
+    name: str
+    licenseText: str
+
+    isOsiApproved: bool | None = None
+    isFsfLibre: bool | None = None
+    standardLicenseHeader: str | None = None
+    licenseComments: str | None = None
+
+    seeAlso: list[HttpUrl] | None = None
+    crossRef: list[SPDXCrossRef] | None = None

--- a/src/bridge/pipelines/bt2gh_for_pr/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
 from bridge.pipelines.utils import load_dict_from_yaml_file
 
-from .map_funcs import map_citation, map_description, map_homepage, map_readme, map_topics
+from .map_funcs import map_citation, map_description, map_homepage, map_license, map_readme, map_topics
 
 
 class MapDestination(BaseModel):
@@ -25,7 +25,7 @@ class MapDestination(BaseModel):
     """
 
     issue: list[str] = ["description", "homepage", "topics"]
-    pr: list[str] = ["citation", "readme"]
+    pr: list[str] = ["citation", "readme", "license"]
 
 
 class MapBioTools2GitHub(ModelsMap):
@@ -91,5 +91,11 @@ class MapBioTools2GitHub(ModelsMap):
                 repo_entry=self.repo.readme,
                 method=Method.FUZZY,
                 fn=map_readme,
+            ),
+            "license": MapItem(
+                schema_entry=self.metadata.license,
+                repo_entry=self.repo.repo.license,
+                method=Method.FUZZY,
+                fn=map_license,
             ),
         }

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/__init__.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/__init__.py
@@ -5,6 +5,7 @@ Individual mapping functions for bio.tools to GitHub.
 from .citation import map_citation
 from .description import map_description
 from .homepage import map_homepage
+from .license import map_license
 from .readme import map_readme
 from .topics import map_topics
 
@@ -14,4 +15,5 @@ __all__ = [
     "map_topics",
     "map_homepage",
     "map_readme",
+    "map_license",
 ]

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -10,7 +10,7 @@ no conflicting description set.
 """
 
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh_issue
+from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh
 from bridge.pipelines.utils import normalize_text
 
 logger = get_user_logger()
@@ -53,9 +53,9 @@ def map_description(gh_description: str | None, bt_description: str | None) -> d
             )
         }
 
-    return reconcile_bt_over_gh_issue(
+    return reconcile_bt_over_gh(
         gh_norm=gh_norm,
         bt_norm=bt_norm,
-        make_issue=make_issue,
+        make_output=make_issue,
         log_label="description",
     )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -16,7 +16,7 @@ from bridge.pipelines.utils import normalize_text
 logger = get_user_logger()
 
 
-def map_description(gh_description: str | None, bt_description: str | None) -> dict[str, str] | None:
+async def map_description(gh_description: str | None, bt_description: str | None) -> dict[str, str] | None:
     """
     Propose a GitHub issue to add a description based on bio.tools metadata,
     using the generic bio.tools-over-GitHub issue policy.
@@ -53,7 +53,7 @@ def map_description(gh_description: str | None, bt_description: str | None) -> d
             )
         }
 
-    return reconcile_bt_over_gh(
+    return await reconcile_bt_over_gh(
         gh_norm=gh_norm,
         bt_norm=bt_norm,
         make_output=make_issue,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/description.py
@@ -5,8 +5,7 @@ This module compares the description recorded in bio.tools with the
 description configured on a GitHub repository and, when appropriate,
 proposes a GitHub issue suggesting that the bio.tools description be
 adopted. It applies a bio.tools-over-GitHub policy that only suggests
-changes when bio.tools provides a description and the repository has
-no conflicting description set.
+changes when bio.tools provides a description.
 """
 
 from bridge.logging import get_user_logger

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -13,7 +13,7 @@ from pydantic import AnyUrl
 
 from bridge.core.biotools import UrlftpType
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh_issue
+from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh
 from bridge.pipelines.utils import canonicalize_url
 
 logger = get_user_logger()
@@ -72,9 +72,9 @@ def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType |
             )
         }
 
-    return reconcile_bt_over_gh_issue(
+    return reconcile_bt_over_gh(
         gh_norm=gh_hp_norm,
         bt_norm=bt_hp_norm,
-        make_issue=make_issue,
+        make_output=make_issue,
         log_label="homepage",
     )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -19,7 +19,7 @@ from bridge.pipelines.utils import canonicalize_url
 logger = get_user_logger()
 
 
-def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType | None) -> dict[str, str] | None:
+async def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType | None) -> dict[str, str] | None:
     """
     Propose a GitHub issue to add a homepage based on bio.tools metadata,
     using the generic bio.tools-over-GitHub issue policy.
@@ -72,7 +72,7 @@ def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: UrlftpType |
             )
         }
 
-    return reconcile_bt_over_gh(
+    return await reconcile_bt_over_gh(
         gh_norm=gh_hp_norm,
         bt_norm=bt_hp_norm,
         make_output=make_issue,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/homepage.py
@@ -4,9 +4,7 @@ Map homepage URL from bio.tools to a GitHub.
 This module compares the homepage URL recorded in bio.tools with the
 homepage (and HTML URL) of a GitHub repository and, when appropriate,
 proposes a GitHub issue suggesting that the bio.tools homepage be added
-to the repository settings. It applies a bio.tools-over-GitHub policy:
-bio.tools is only used to suggest a homepage when GitHub has no
-conflicting homepage configured.
+to the repository settings. It applies a bio.tools-over-GitHub policy.
 """
 
 from pydantic import AnyUrl
@@ -28,9 +26,9 @@ async def map_homepage(gh_schema: dict[AnyUrl | str | None], bt_homepage: Urlftp
     are compared in canonicalized form to avoid spurious differences due
     to trailing slashes, case, or query parameter ordering.
     If the bio.tools homepage is equal to the repository HTML URL,
-    no suggestion is made. If GitHub already has a different homepage configured, t
-    hat value is treated as authoritative and a conflict is logged without proposing an issue.
-    Only when the bio.tools homepage is present, differs from the HTML URL,
+    no suggestion is made. If GitHub already has a different homepage configured,
+    that value is treated as authoritative and a conflict is logged while still proposing an issue.
+    When the bio.tools homepage is present, differs from the HTML URL,
     and the GitHub homepage is unset does this function propose an issue.
 
     Parameters

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -1,5 +1,10 @@
 """
-TODO
+Map license metadata from bio.tools to GitHub.
+
+This module compares the license recorded in bio.tools with the license
+detected on a GitHub repository and, when appropriate, proposes a pull
+request that adds a full LICENSE file based on the SPDX canonical text.
+It applies a bio.tools-over-GitHub policy.
 """
 
 from bridge.builders import compose_spdx_license_metadata
@@ -15,12 +20,36 @@ logger = get_user_logger()
 
 async def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
     """
-    TODO
+    Propose a GitHub pull request to add a LICENSE file based on bio.tools
+    license metadata, using the generic bio.tools-over-GitHub policy.
+
+    The GitHub license (when present) is normalized via its SPDX identifier
+    and compared against the bio.tools license enum. If bio.tools provides
+    a license, the full canonical license text is fetched from the SPDX service
+    and proposed as a new ``LICENSE.txt`` file. If GitHub already declares a different license,
+    that value is treated as authoritative, a conflict is logged, but the pull
+    request is still proposed.
+
+    Parameters
+    ----------
+    gh_license : GHLicense | None
+        License metadata detected on the GitHub repository, or ``None``
+        if no license is declared.
+    bt_license : BTLicense | None
+        License value from the bio.tools entry, represented as a bio.tools
+        license enum, or ``None`` if not available.
+
+    Returns
+    -------
+    dict[str, str] | None
+        A dictionary with the filename ``LICENSE.txt`` as key and the
+        full license text as value, or ``None`` if no pull request should
+        be created under the policy.
     """
     gh_norm = find_matching_enum_member(gh_license.spdx_id, BTLicense) if gh_license else None
     bt_norm = bt_license
 
-    async def make_pr(bt_value: BTLicense) -> dict[str, str]:
+    async def make_pr(bt_value: BTLicense) -> dict[str, str] | None:
         spdx_id = bt_value.value
         try:
             license: SPDXLicense = await compose_spdx_license_metadata(spdx_id)

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -13,23 +13,25 @@ from bridge.pipelines.utils import find_matching_enum_member
 logger = get_user_logger()
 
 
-def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
+async def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
     """
     TODO
     """
     gh_norm = find_matching_enum_member(gh_license.spdx_id, BTLicense) if gh_license else None
     bt_norm = bt_license
 
-    def make_pr(bt_value: BTLicense) -> dict[str, str]:
+    async def make_pr(bt_value: BTLicense) -> dict[str, str]:
         spdx_id = bt_value.spdx_id
         try:
-            license: SPDXLicense = compose_spdx_license_metadata(spdx_id)
+            license: SPDXLicense = await compose_spdx_license_metadata(spdx_id)
             full_text = license.full_text
             logger.added(f"LICENSE.txt with full text for SPDX ID '{spdx_id}'")
             return {"LICENSE.txt": full_text}
         except Exception:
             logger.unchanged(f"could not retrieve full text for SPDX ID '{spdx_id}'")
             return None
+
+        exit(1)
 
     return reconcile_bt_over_gh(
         gh_norm=gh_norm,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -4,6 +4,7 @@ TODO
 
 from bridge.core.biotools import License as BTLicense
 from bridge.core.github_repo import License as GHLicense
+from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh
 from bridge.pipelines.utils import find_matching_enum_member
 
 
@@ -11,6 +12,15 @@ def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> d
     """
     TODO
     """
-    find_matching_enum_member(gh_license.spdx_id, BTLicense) if gh_license else None
+    gh_norm = find_matching_enum_member(gh_license.spdx_id, BTLicense) if gh_license else None
+    bt_norm = bt_license
 
-    return {"a": "b"}  # TODO: implement license mapping logic
+    def make_pr(bt_value: BTLicense) -> dict[str, str]:
+        return {"a": "b"}
+
+    return reconcile_bt_over_gh(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        make_output=make_pr,
+        log_label="license",
+    )

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -31,9 +31,7 @@ async def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None
             logger.unchanged(f"could not retrieve full text for SPDX ID '{spdx_id}'")
             return None
 
-        exit(1)
-
-    return reconcile_bt_over_gh(
+    return await reconcile_bt_over_gh(
         gh_norm=gh_norm,
         bt_norm=bt_norm,
         make_output=make_pr,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -21,14 +21,14 @@ async def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None
     bt_norm = bt_license
 
     async def make_pr(bt_value: BTLicense) -> dict[str, str]:
-        spdx_id = bt_value.spdx_id
+        spdx_id = bt_value.value
         try:
             license: SPDXLicense = await compose_spdx_license_metadata(spdx_id)
-            full_text = license.full_text
+            full_text = license.licenseText
             logger.added(f"LICENSE.txt with full text for SPDX ID '{spdx_id}'")
             return {"LICENSE.txt": full_text}
-        except Exception:
-            logger.unchanged(f"could not retrieve full text for SPDX ID '{spdx_id}'")
+        except Exception as e:
+            logger.unchanged(f"could not retrieve full text for SPDX ID '{spdx_id}': {e}")
             return None
 
     return await reconcile_bt_over_gh(

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -1,0 +1,13 @@
+"""
+TODO
+"""
+
+from bridge.core.biotools import License as BTLicense
+from bridge.core.github_repo import License as GHLicense
+
+
+def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
+    """
+    TODO
+    """
+    return {"a": "b"}  # TODO: implement license mapping logic

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -2,10 +2,15 @@
 TODO
 """
 
+from bridge.builders import compose_spdx_license_metadata
+from bridge.core import SPDXLicense
 from bridge.core.biotools import License as BTLicense
 from bridge.core.github_repo import License as GHLicense
+from bridge.logging import get_user_logger
 from bridge.pipelines.policies.bt2gh import reconcile_bt_over_gh
 from bridge.pipelines.utils import find_matching_enum_member
+
+logger = get_user_logger()
 
 
 def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
@@ -16,7 +21,15 @@ def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> d
     bt_norm = bt_license
 
     def make_pr(bt_value: BTLicense) -> dict[str, str]:
-        return {"a": "b"}
+        spdx_id = bt_value.spdx_id
+        try:
+            license: SPDXLicense = compose_spdx_license_metadata(spdx_id)
+            full_text = license.full_text
+            logger.added(f"LICENSE.txt with full text for SPDX ID '{spdx_id}'")
+            return {"LICENSE.txt": full_text}
+        except Exception:
+            logger.unchanged(f"could not retrieve full text for SPDX ID '{spdx_id}'")
+            return None
 
     return reconcile_bt_over_gh(
         gh_norm=gh_norm,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/license.py
@@ -4,10 +4,13 @@ TODO
 
 from bridge.core.biotools import License as BTLicense
 from bridge.core.github_repo import License as GHLicense
+from bridge.pipelines.utils import find_matching_enum_member
 
 
 def map_license(gh_license: GHLicense | None, bt_license: BTLicense | None) -> dict[str, str] | None:
     """
     TODO
     """
+    find_matching_enum_member(gh_license.spdx_id, BTLicense) if gh_license else None
+
     return {"a": "b"}  # TODO: implement license mapping logic

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/topics.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/topics.py
@@ -11,7 +11,7 @@ bio.tools-on-top-of-GitHub additive policy.
 
 from bridge.core.biotools import FunctionItem, TopicItem
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies.bt2gh import reconcile_bt_ontop_gh_issue
+from bridge.pipelines.policies.bt2gh import reconcile_bt_ontop_gh
 
 logger = get_user_logger()
 
@@ -153,10 +153,10 @@ def map_topics(gh_topics: list[str] | None, bt_edam: dict[str, any] | None) -> d
             )
         }
 
-    return reconcile_bt_ontop_gh_issue(
+    return reconcile_bt_ontop_gh(
         gh_norm=gh_terms,
         bt_norm=bt_terms,
-        make_issue=make_issue,
+        make_output=make_issue,
         log_label="EDAM terms",
     )
 

--- a/src/bridge/pipelines/policies/bt2gh/__init__.py
+++ b/src/bridge/pipelines/policies/bt2gh/__init__.py
@@ -2,10 +2,10 @@
 Generic reconciliation policies for bio.tools to GitHub mapping.
 """
 
-from .reconcile_bt_ontop_gh import reconcile_bt_ontop_gh_issue
-from .reconcile_bt_over_gh import reconcile_bt_over_gh_issue
+from .reconcile_bt_ontop_gh import reconcile_bt_ontop_gh
+from .reconcile_bt_over_gh import reconcile_bt_over_gh
 
 __all__ = [
-    "reconcile_bt_ontop_gh_issue",
-    "reconcile_bt_over_gh_issue",
+    "reconcile_bt_ontop_gh",
+    "reconcile_bt_over_gh",
 ]

--- a/src/bridge/pipelines/policies/bt2gh/reconcile_bt_ontop_gh.py
+++ b/src/bridge/pipelines/policies/bt2gh/reconcile_bt_ontop_gh.py
@@ -2,8 +2,8 @@
 Generic reconciliation policies for bio.tools-to-GitHub *additive* mappings.
 
 This module provides a generic function to determine whether a GitHub issue
-should be proposed based on bio.tools metadata, according to a policy that
-treats bio.tools values as additions on top of existing GitHub values.
+or pull request should be proposed based on bio.tools metadata, according to a
+policy that treats bio.tools values as additions on top of existing GitHub values.
 """
 
 from collections.abc import Callable
@@ -15,16 +15,16 @@ logger = get_user_logger()
 
 BTN = TypeVar("BTN")  # element type for bio.tools set
 GHN = TypeVar("GHN")  # element type for GitHub set (usually same as BTN)
-ISSUE = TypeVar("ISSUE")  # issue payload type, e.g. dict[str, str]
+OUTPUT = TypeVar("OUTPUT")  # issue/pr payload type, e.g. dict[str, str]
 
 
-def reconcile_bt_ontop_gh_issue(
+def reconcile_bt_ontop_gh(
     *,
     gh_norm: set[GHN] | None,
     bt_norm: set[BTN] | None,
-    make_issue: Callable[[set[BTN]], ISSUE],
+    make_output: Callable[[set[BTN]], OUTPUT],
     log_label: str,
-) -> ISSUE | None:
+) -> OUTPUT | None:
     """
     Apply a generic bio.tools-on-top-of-GitHub policy for additive metadata.
 
@@ -36,14 +36,14 @@ def reconcile_bt_ontop_gh_issue(
 
     Policy:
     1. If ``bt_norm`` is ``None`` or empty, bio.tools is treated as silent and
-       no issue is proposed. An "unchanged" log entry is emitted.
+       no issue/pr is proposed. An "unchanged" log entry is emitted.
     2. If ``gh_norm`` is ``None`` or empty, all values from ``bt_norm`` are
-       considered missing and an issue is proposed with an "added" log entry.
+       considered missing and an issue/pr is proposed with an "added" log entry.
     3. If both ``gh_norm`` and ``bt_norm`` are non-empty:
        - If all values in ``bt_norm`` are already present in ``gh_norm``,
-         no issue is proposed and an "exact" log entry is emitted.
+         no issue/pr is proposed and an "exact" log entry is emitted.
        - Otherwise, the set difference ``missing = bt_norm - gh_norm`` is
-         passed to ``make_issue`` and an "added" log entry is emitted.
+         passed to ``make_output`` and an "added" log entry is emitted.
 
     Parameters
     ----------
@@ -53,8 +53,8 @@ def reconcile_bt_ontop_gh_issue(
     bt_norm : set[BTN] | None
         Normalized set of values from bio.tools, or ``None`` if bio.tools
         does not provide values for this field.
-    make_issue : Callable[[set[BTN]], ISSUE]
-        Callable that constructs an issue payload from the set of missing
+    make_output : Callable[[set[BTN]], OUTPUT]
+        Callable that constructs an issue/pr payload from the set of missing
         bio.tools values.
     log_label : str
         Short label used in log messages to identify the metadata field
@@ -72,7 +72,7 @@ def reconcile_bt_ontop_gh_issue(
 
     if not gh_norm:
         logger.added(f"bio.tools {log_label} additions: {bt_norm!r}")
-        return make_issue(bt_norm)
+        return make_output(bt_norm)
 
     missing = bt_norm - gh_norm  # set difference
 
@@ -81,4 +81,4 @@ def reconcile_bt_ontop_gh_issue(
         return None
 
     logger.added(f"bio.tools {log_label} additions missing on GitHub: {missing!r}")
-    return make_issue(missing)
+    return make_output(missing)

--- a/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
+++ b/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
@@ -19,7 +19,7 @@ GHN = TypeVar("GHN")  # normalized GitHub representation
 OUTPUT = TypeVar("OUTPUT")  # issue payload type, e.g. dict[str, str]
 
 
-def reconcile_bt_over_gh(
+async def reconcile_bt_over_gh(
     *,
     gh_norm: GHN | None,
     bt_norm: BTN | None,
@@ -79,7 +79,7 @@ def reconcile_bt_over_gh(
             return None
 
         logger.conflict(f"existing GitHub {log_label} {gh_norm!r} differs from bio.tools {log_label} {bt_norm!r}")
-        return make_output(bt_norm)
+        return await make_output(bt_norm)
 
     logger.added(f"{log_label}: {bt_norm!r}")
-    return make_output(bt_norm)
+    return await make_output(bt_norm)

--- a/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
+++ b/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
@@ -7,10 +7,11 @@ a policy that treats bio.tools as authoritative while preserving existing GitHub
 values when bio.tools is silent.
 """
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
 from bridge.logging import get_user_logger
+from bridge.utils import maybe_await
 
 logger = get_user_logger()
 
@@ -23,7 +24,7 @@ async def reconcile_bt_over_gh(
     *,
     gh_norm: GHN | None,
     bt_norm: BTN | None,
-    make_output: Callable[[BTN], OUTPUT],
+    make_output: Callable[[BTN], Awaitable[OUTPUT] | OUTPUT],
     log_label: str,
 ) -> OUTPUT | None:
     """
@@ -56,17 +57,17 @@ async def reconcile_bt_over_gh(
     bt_norm : BTN | None
         Normalized representation of the bio.tools value, or ``None`` if
         no value is recorded in bio.tools.
-    make_output : Callable[[BTN], OUTPUT]
+    make_output : Callable[[BTN], Awaitable[OUTPUT] | OUTPUT]
         Callable that constructs an issue/pr payload from the normalized
-        bio.tools value.
+        bio.tools value. The callable may be asynchronous.
     log_label : str
         Short label used in log messages to identify the metadata field
         (e.g., ``"description"``, ``"homepage"``, ``"license"``).
 
     Returns
     -------
-    ISSUE | None
-        Issue payload to propose according to the policy, or ``None`` if
+    OUTPUT | None
+        Issue/pr payload to propose according to the policy, or ``None`` if
         no issue should be created.
     """
     if bt_norm is None:
@@ -79,7 +80,7 @@ async def reconcile_bt_over_gh(
             return None
 
         logger.conflict(f"existing GitHub {log_label} {gh_norm!r} differs from bio.tools {log_label} {bt_norm!r}")
-        return await make_output(bt_norm)
+        return await maybe_await(make_output, bt_norm)
 
     logger.added(f"{log_label}: {bt_norm!r}")
-    return await make_output(bt_norm)
+    return await maybe_await(make_output, bt_norm)

--- a/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
+++ b/src/bridge/pipelines/policies/bt2gh/reconcile_bt_over_gh.py
@@ -2,9 +2,9 @@
 Generic reconciliation policies for bio.tools to GitHub mapping.
 
 This module provides a generic function to determine whether a GitHub issue
-should be proposed based on bio.tools metadata, according to a policy that
-treats bio.tools as authoritative while preserving existing GitHub values
-when bio.tools is silent.
+or pull request should be proposed based on bio.tools metadata, according to
+a policy that treats bio.tools as authoritative while preserving existing GitHub
+values when bio.tools is silent.
 """
 
 from collections.abc import Callable
@@ -16,37 +16,37 @@ logger = get_user_logger()
 
 BTN = TypeVar("BTN")  # normalized bio.tools representation
 GHN = TypeVar("GHN")  # normalized GitHub representation
-ISSUE = TypeVar("ISSUE")  # issue payload type, e.g. dict[str, str]
+OUTPUT = TypeVar("OUTPUT")  # issue payload type, e.g. dict[str, str]
 
 
-def reconcile_bt_over_gh_issue(
+def reconcile_bt_over_gh(
     *,
     gh_norm: GHN | None,
     bt_norm: BTN | None,
-    make_issue: Callable[[BTN], ISSUE],
+    make_output: Callable[[BTN], OUTPUT],
     log_label: str,
-) -> ISSUE | None:
+) -> OUTPUT | None:
     """
     Apply a generic bio.tools-over-GitHub policy to decide whether to
-    propose a GitHub issue based on bio.tools metadata.
+    propose a GitHub issue or pull request based on bio.tools metadata.
 
     This function operates on *normalized* representations of GitHub and
-    bio.tools values (``gh_norm`` and ``bt_norm``) and returns an issue
+    bio.tools values (``gh_norm`` and ``bt_norm``) and returns an issue/pr
     payload constructed from the bio.tools value when applicable.
 
     Policy:
     1. If ``bt_norm`` is ``None``, bio.tools is treated as silent and no
-       issue is proposed. An "unchanged" log entry is emitted.
+       issue/pr is proposed. An "unchanged" log entry is emitted.
     2. If ``gh_norm`` is not ``None`` and equals ``bt_norm``, the values
-       are considered aligned and no issue is proposed.
+       are considered aligned and no issue/pr is proposed.
        An "exact" log entry is emitted.
     3. If ``gh_norm`` is not ``None`` and differs from ``bt_norm``, GitHub
        is treated as conflicting with bio.tools. A conflict log entry is
-       emitted and an issue proposing the bio.tools value is constructed
-       via ``make_issue(bt_norm)``.
+       emitted and an issue/pr proposing the bio.tools value is constructed
+       via ``make_output(bt_norm)``.
     4. If ``gh_norm`` is ``None`` and ``bt_norm`` is not ``None``, GitHub
-       is missing the value and an issue proposing the bio.tools value is
-       constructed via ``make_issue(bt_norm)`` with an added log entry.
+       is missing the value and an issue/pr proposing the bio.tools value is
+       constructed via ``make_output(bt_norm)`` with an added log entry.
 
     Parameters
     ----------
@@ -56,8 +56,8 @@ def reconcile_bt_over_gh_issue(
     bt_norm : BTN | None
         Normalized representation of the bio.tools value, or ``None`` if
         no value is recorded in bio.tools.
-    make_issue : Callable[[BTN], ISSUE]
-        Callable that constructs an issue payload from the normalized
+    make_output : Callable[[BTN], OUTPUT]
+        Callable that constructs an issue/pr payload from the normalized
         bio.tools value.
     log_label : str
         Short label used in log messages to identify the metadata field
@@ -79,7 +79,7 @@ def reconcile_bt_over_gh_issue(
             return None
 
         logger.conflict(f"existing GitHub {log_label} {gh_norm!r} differs from bio.tools {log_label} {bt_norm!r}")
-        return make_issue(bt_norm)
+        return make_output(bt_norm)
 
     logger.added(f"{log_label}: {bt_norm!r}")
-    return make_issue(bt_norm)
+    return make_output(bt_norm)

--- a/src/bridge/services/__init__.py
+++ b/src/bridge/services/__init__.py
@@ -8,6 +8,7 @@ from .europe_pmc import EuropePMCIngestor
 from .github import GitHubIngestor, GitHubRepoProvider
 from .huggingface import HuggingFaceProvider
 from .protocols import ChatMessage
+from .spdx import SPDXLicenseIngestor
 
 __all__ = [
     "GitHubRepoProvider",
@@ -16,4 +17,5 @@ __all__ = [
     "HuggingFaceProvider",
     "ChatMessage",
     "EuropePMCIngestor",
+    "SPDXLicenseIngestor",
 ]

--- a/src/bridge/services/spdx/__init__.py
+++ b/src/bridge/services/spdx/__init__.py
@@ -1,0 +1,9 @@
+"""
+SPDX integrations: async metadata ingestor from SPDX license list.
+"""
+
+from .spdx_ingestor import SPDXLicenseIngestor
+
+__all__ = [
+    "SPDXLicenseIngestor",
+]

--- a/src/bridge/services/spdx/spdx_ingestor.py
+++ b/src/bridge/services/spdx/spdx_ingestor.py
@@ -1,0 +1,102 @@
+"""
+Async client for the SPDX license list.
+Fetches a license by SPDX identifier and returns the full JSON payload,
+including the canonical license text.
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from bridge.config import settings
+from bridge.services.protocols import Ingestor
+
+logger = logging.getLogger(__name__)
+
+
+class SPDXLicenseNotFoundError(Exception):
+    """Raised when no SPDX license matches the given SPDX identifier."""
+
+
+class SPDXLicenseIngestor(Ingestor):
+    """
+    Ingest license metadata from the SPDX license list by SPDX identifier.
+
+    This client fetches the JSON representation of a single license from
+    the SPDX license list, which includes the canonical license text
+    (``licenseText``), name, and other metadata.
+
+    Parameters
+    ----------
+    spdx_id : str
+        SPDX license identifier (e.g. ``"MIT"``, ``"GPL-3.0-only"``).
+    """
+
+    def __init__(self, spdx_id: str):
+        if not spdx_id:
+            raise ValueError("SPDX identifier must be a non-empty string.")
+        self.spdx_id = spdx_id
+
+    async def _get(self) -> dict[str, Any]:
+        """
+        Perform async GET request to the SPDX license JSON endpoint.
+
+        Returns
+        -------
+        dict
+            JSON response for the given SPDX license.
+
+        Raises
+        ------
+        httpx.RequestError
+            For network-related issues.
+        httpx.HTTPStatusError
+            For non-2xx HTTP responses.
+        """
+        # SPDX per-license JSON: {base}/{ID}.json, e.g. https://spdx.org/licenses/MIT.json
+        base = settings.spdx_license_base
+        url = f"{base}/{self.spdx_id}.json"
+        try:
+            logger.debug(f"Fetching SPDX license JSON: {url}")
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                data = resp.json()
+                logger.debug(f"Fetched SPDX license data for ID {self.spdx_id} successfully")
+                return data
+        except httpx.RequestError as e:
+            logger.error(f"Network error while fetching {url}: {e}")
+            raise
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"HTTP error from SPDX license endpoint: {e.response.status_code} for {url}")
+            raise
+
+    async def fetch(self) -> dict[str, Any]:
+        """
+        Fetch the SPDX license record for the specified SPDX identifier.
+
+        Returns
+        -------
+        dict
+            JSON metadata for the SPDX license, including at least
+            ``licenseId``, ``name``, and ``licenseText`` fields.
+
+        Raises
+        ------
+        SPDXLicenseNotFoundError
+            If the SPDX service does not return a valid license record.
+        httpx.RequestError, httpx.HTTPStatusError
+            For network/HTTP issues.
+        """
+        data = await self._get()
+
+        # SPDX license JSON should have a "licenseId" matching the request.
+        license_id = data.get("licenseId")
+        if not license_id:
+            msg = f"SPDX license JSON for ID {self.spdx_id!r} missing 'licenseId' field"
+            logger.warning(msg)
+            raise SPDXLicenseNotFoundError(msg)
+
+        logger.info(f"Ingested SPDX license data for {self.spdx_id} successfully")
+        return data


### PR DESCRIPTION
## Summary
- Fetch full license models from spdx
- Update biotools over github policy to accept async methods
- Update the same policy to wrk for both issues and pr's
- Map licenses from bio.tools to GitHub 

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #28 