### PR TITLE
Map publications gh CFF -> bt

### DIFF
--- a/src/bridge/handlers/extract_meta_from_repo.py
+++ b/src/bridge/handlers/extract_meta_from_repo.py
@@ -49,6 +49,7 @@ async def extract_meta_from_repo(schema: str, repo_type: str, **kwargs) -> str:
 
     metadata_composer = get_schema_composer(schema)
     repo_composer, repo_provider = get_repo_components(repo_type)
+    repo_provider = repo_provider()
     pipeline, args_model = get_pipeline(schema, repo_type, PipelineGoal.EXTRACT_METADATA)
 
     repo_model = await repo_composer(**kwargs)
@@ -58,8 +59,8 @@ async def extract_meta_from_repo(schema: str, repo_type: str, **kwargs) -> str:
     with repo_provider.clone_context(repo_model.repo.full_name) as cloned_repo:
         pipeline_kwargs = {
             "repo_model": repo_model,
-            "existing_metadata": metadata,
             "repo_path": cloned_repo,
+            "existing_metadata": metadata,
         }
         merged_kwargs = {**pipeline_kwargs, **kwargs}
         pipeline_args = args_model(**merged_kwargs)

--- a/src/bridge/handlers/extract_meta_from_repo.py
+++ b/src/bridge/handlers/extract_meta_from_repo.py
@@ -48,23 +48,25 @@ async def extract_meta_from_repo(schema: str, repo_type: str, **kwargs) -> str:
     )
 
     metadata_composer = get_schema_composer(schema)
-    repo_composer, _ = get_repo_components(repo_type)
+    repo_composer, repo_provider = get_repo_components(repo_type)
     pipeline, args_model = get_pipeline(schema, repo_type, PipelineGoal.EXTRACT_METADATA)
 
     repo_model = await repo_composer(**kwargs)
     identifier = kwargs.get("identifier")
     metadata = await metadata_composer(**kwargs) if identifier else None
 
-    pipeline_kwargs = {
-        "repo_model": repo_model,
-        "existing_metadata": metadata,
-    }
-    merged_kwargs = {**pipeline_kwargs, **kwargs}
-    pipeline_args = args_model(**merged_kwargs)
-    result = await pipeline(pipeline_args)
+    with repo_provider.clone_context(repo_model.repo.full_name) as cloned_repo:
+        pipeline_kwargs = {
+            "repo_model": repo_model,
+            "existing_metadata": metadata,
+            "repo_path": cloned_repo,
+        }
+        merged_kwargs = {**pipeline_kwargs, **kwargs}
+        pipeline_args = args_model(**merged_kwargs)
+        result = await pipeline(pipeline_args)
 
-    result_json = result.model_dump_json(exclude_none=True, indent=2)
-    logger.info(
-        f"Extracted {schema} metadata from {repo_type} repo {kwargs.get('owner')}/{kwargs.get('repo')} successfully"
-    )
-    return result_json
+        result_json = result.model_dump_json(exclude_none=True, indent=2)
+        logger.info(
+            f"Extracted {schema} metadata from {repo_type} repo {kwargs.get('owner')}/{kwargs.get('repo')} successfully"
+        )
+        return result_json

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -271,7 +271,7 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     ----------
     gh_citation_cff : dict[str, Any]
         Parsed content of an existing CITATION.cff file from the GitHub
-        repository, or ``None`` if no file exists.
+        repository.
     bt_params : dict[str, Any]
         The bio.tools tool metadata as a dictionary.
         Expected keys include:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -13,7 +13,6 @@ existing preferred-citation (if any) > bio.tools primary publications > other
 publications.
 """
 
-from collections.abc import Mapping
 from typing import Any
 
 import yaml
@@ -22,7 +21,7 @@ from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import TypeEnum2
 from bridge.logging import get_user_logger
-from bridge.pipelines.shared.publications import deduplicate_references, ref_ids
+from bridge.pipelines.shared.publications import deduplicate_references, extract_cff_references
 from bridge.pipelines.utils import (
     normalize_dict_strings,
     normalize_pydantic_model_strings,
@@ -198,63 +197,6 @@ def _merge_top_level_metadata(
     return merged
 
 
-def _extract_gh_references(
-    gh_citation_cff: dict[str, Any] | None,
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """
-    Extract publication information from an existing CITATION.cff dictionary.
-
-    This helper parses an existing CFF structure and returns:
-    - the list of reference entries, and
-    - the preferred-citation entry, if present.
-
-    The preferred citation is ensured to be part of the references list:
-    if it is not already present, it is appended.
-
-    Parameters
-    ----------
-    gh_citation_cff : dict[str, Any] | None
-        TParsed content of an existing CITATION.cff file,
-        or ``None`` if no file exists.
-
-    Returns
-    -------
-    tuple[list[dict[str, Any]], dict[str, Any] | None]
-        A tuple of:
-        - A list of reference dictionaries extracted from the CFF.
-        - The preferred-citation dictionary, or ``None`` if not present.
-    """
-    if not gh_citation_cff:
-        return [], None
-
-    gh_citation_cff = normalize_dict_strings(gh_citation_cff)
-
-    gh_references = gh_citation_cff.get("references") or []
-    gh_references = [r for r in gh_references if isinstance(r, Mapping)]
-
-    gh_preferred = gh_citation_cff.get("preferred-citation")
-    if isinstance(gh_preferred, Mapping):
-        gh_preferred = dict(gh_preferred)  # shallow copy
-    else:
-        gh_preferred = None
-
-    # ensure preferred-citation is included in references if present
-    if gh_preferred is not None:
-        pref_ids = ref_ids(gh_preferred)
-        in_refs = any(ref_ids(r) & pref_ids for r in gh_references)
-        if not in_refs:
-            gh_references.append(gh_preferred)
-
-    if gh_references:
-        logger.note(
-            f"CITATION.cff is not empty. Found {len(gh_references)} reference(s) to merge with bio.tools metadata."
-        )
-    else:
-        logger.note("CITATION.cff exists but contains no references. Using only bio.tools metadata.")
-
-    return gh_references, gh_preferred
-
-
 def _compose_citation(
     base_cff: dict[str, Any],
     references: list[Publication | dict[str, Any]],
@@ -352,7 +294,14 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
     bt_references: list[Publication] = []
     bt_primary_references: list[Publication] = []
 
-    gh_references, gh_preferred = _extract_gh_references(gh_citation_cff)
+    gh_references, gh_preferred = extract_cff_references(gh_citation_cff)
+
+    if gh_references:
+        logger.note(
+            f"CITATION.cff is not empty. Found {len(gh_references)} reference(s) to merge with bio.tools metadata."
+        )
+    else:
+        logger.note("CITATION.cff exists but contains no references. Using only bio.tools metadata.")
 
     for pub in bt_publication or []:
         try:

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/citation.py
@@ -22,116 +22,14 @@ from bridge.builders import compose_europe_pmc_metadata
 from bridge.core import Publication
 from bridge.core.biotools import TypeEnum2
 from bridge.logging import get_user_logger
+from bridge.pipelines.shared.publications import deduplicate_references, ref_ids
 from bridge.pipelines.utils import (
     normalize_dict_strings,
     normalize_pydantic_model_strings,
-    normalize_text,
     object_to_primitive,
 )
 
 logger = get_user_logger()
-
-
-def _ref_ids(ref: Publication | Mapping[str, Any]) -> set[str]:
-    """
-    Extract a normalized set of identifiers for a publication-like object.
-    This function collects all available identifiers and returns
-    them as normalized strings, which can then be used for deduplication.
-
-    Normalized identifiers include (when present):
-    - DOI
-    - PMID
-    - PMCID
-    - title
-
-    Parameters
-    ----------
-    ref : Publication | Mapping[str, Any]
-        The Publication object or dictionary representing a publication.
-
-    Returns
-    -------
-    set[str]
-        A set of normalized identifier strings.
-        The set may be empty if no identifiers are present.
-
-    Raises
-    ------
-    TypeError
-        If `ref` is neither a `Publication` instance nor a mapping.
-    """
-    if isinstance(ref, Mapping):
-        doi = ref.get("doi", None)
-        pmid = ref.get("pmid", None)
-        pmcid = ref.get("pmcid", None)
-        title = ref.get("title", None)
-    elif isinstance(ref, Publication):
-        doi = getattr(ref, "doi", None)
-        pmid = getattr(ref, "pmid", None)
-        pmcid = getattr(ref, "pmcid", None)
-        title = getattr(ref, "title", None)
-    else:
-        raise TypeError("ref must be a Publication or a Mapping")
-
-    ids: set[str] = set()
-
-    if doi:
-        ids.add(f"doi:{normalize_text(str(doi))}")
-    if pmid:
-        ids.add(f"pmid:{str(pmid).strip()}")
-    if pmcid:
-        ids.add(f"pmcid:{str(pmcid).strip()}")
-    if title:
-        ids.add(f"title:{normalize_text(str(title))}")
-
-    return ids
-
-
-def _deduplicate_references(references: list[Publication | Mapping[str, Any]]) -> list[Publication | Mapping[str, Any]]:
-    """
-    Deduplicate a list of publication-like objects based on shared identifiers.
-
-    Two references are considered duplicates if they share at least one
-    normalized identifier (DOI, PMID, PMCID, or title). The first occurrence
-    in the input list is retained; all later duplicates are dropped.
-
-    Parameters
-    ----------
-    references : list[Publication | Mapping[str, Any]]
-        List of references (models or dicts) to deduplicate.
-
-    Returns
-    -------
-    list[Publication | Mapping[str, Any]]
-        Deduplicated list of references, preserving original order for
-        the first occurrence of each logical publication.
-    """
-    seen_identifier_sets: list[set[str]] = []
-    deduplicated: list[Publication | Mapping[str, Any]] = []
-
-    for ref in references:
-        current_ids = _ref_ids(ref)
-
-        # if we have no identifiers at all, treat as unique
-        if not current_ids:
-            deduplicated.append(ref)
-            continue
-
-        duplicate = False
-        for seen_ids in seen_identifier_sets:
-            if current_ids & seen_ids:  # intersection
-                duplicate = True
-                # merge identifier sets to strengthen future matching
-                seen_ids.update(current_ids)
-                break
-
-        if duplicate:
-            continue
-
-        seen_identifier_sets.append(set(current_ids))
-        deduplicated.append(ref)
-
-    return deduplicated
 
 
 def _key_func(r: Publication | dict[str, Any]) -> tuple[int, str]:
@@ -342,8 +240,8 @@ def _extract_gh_references(
 
     # ensure preferred-citation is included in references if present
     if gh_preferred is not None:
-        pref_ids = _ref_ids(gh_preferred)
-        in_refs = any(_ref_ids(r) & pref_ids for r in gh_references)
+        pref_ids = ref_ids(gh_preferred)
+        in_refs = any(ref_ids(r) & pref_ids for r in gh_references)
         if not in_refs:
             gh_references.append(gh_preferred)
 
@@ -470,7 +368,7 @@ async def map_citation(gh_citation_cff: dict[str, Any], bt_params: dict[str, Any
         except Exception as e:
             logger.note(f"Could not resolve publication {pub}: {e}")
 
-    references = _deduplicate_references(gh_references + bt_references)
+    references = deduplicate_references(gh_references + bt_references)
 
     preferred_reference = _choose_preferred_citation(
         references=references,

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -24,11 +24,14 @@ class GitHubToBiotoolsForMetaPipelineArgs(PipelineArgs):
     ----------
     repo_model : GitHubRepoModel
         The source GitHub repository model.
+    repo_path : str
+        The local path to the cloned GitHub repository.
     existing_metadata : BiotoolsToolModel | None
         Existing bio.tools metadata model, if available. Default is None.
     """
 
     repo_model: GitHubRepoModel
+    repo_path: str
     existing_metadata: BiotoolsToolModel | None = None
 
 

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -73,6 +73,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
     mapper = MapGitHub2BioTools(
         repo=github_repo,
         metadata=args.existing_metadata,
+        repo_path=args.repo_path,
     )
 
     biotools_metadata = BiotoolsToolModel(

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -81,6 +81,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         license=await mapper.map["license"].run(),
         version=await mapper.map["version"].run(),
         documentation=await mapper.map["documentation"].run(),
+        publication=await mapper.map["publication"].run(),
     )
 
     biotools_url = settings.biotools_url

--- a/src/bridge/pipelines/gh2bt_for_meta/map.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map.py
@@ -2,6 +2,8 @@
 Mapping classes for GitHub to bio.tools.
 """
 
+from pathlib import Path
+
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
 from bridge.pipelines.utils import load_dict_from_yaml_file
 
@@ -21,6 +23,10 @@ class MapGitHub2BioTools(ModelsMap):
     """
     Map bio.tools metadata record to GitHub
     """
+
+    def __init__(self, repo, metadata, repo_path: str):
+        super().__init__(repo=repo, metadata=metadata)
+        self.repo_path = Path(repo_path)
 
     @property
     def map(self) -> dict[str, MapItem]:
@@ -92,7 +98,7 @@ class MapGitHub2BioTools(ModelsMap):
             ),
             "publication": MapItem(
                 schema_entry=self.metadata.publication,
-                repo_entry=load_dict_from_yaml_file(self.repo_path / "CITATION.cff"),  # TODO: pass full repo?
+                repo_entry=load_dict_from_yaml_file(self.repo_path / "CITATION.cff"),
                 method=Method.FUZZY,
                 fn=map_publication,
             ),

--- a/src/bridge/pipelines/gh2bt_for_meta/map.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map.py
@@ -3,6 +3,7 @@ Mapping classes for GitHub to bio.tools.
 """
 
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
+from bridge.pipelines.utils import load_dict_from_yaml_file
 
 from .map_funcs import (
     map_description,
@@ -11,6 +12,7 @@ from .map_funcs import (
     map_language,
     map_license,
     map_maturity,
+    map_publication,
     map_version,
 )
 
@@ -87,5 +89,11 @@ class MapGitHub2BioTools(ModelsMap):
                 repo_entry=self.repo.latest_release.tag_name,
                 method=Method.EXACT,
                 fn=map_version,
+            ),
+            "publication": MapItem(
+                schema_entry=self.metadata.publication,
+                repo_entry=load_dict_from_yaml_file(self.repo_path / "CITATION.cff"),  # TODO: pass full repo?
+                method=Method.FUZZY,
+                fn=map_publication,
             ),
         }

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/__init__.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/__init__.py
@@ -8,6 +8,7 @@ from .homepage import map_homepage
 from .language import map_language
 from .license import map_license
 from .maturity import map_maturity
+from .publication import map_publication
 from .version import map_version
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "map_license",
     "map_maturity",
     "map_version",
+    "map_publication",
 ]

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
@@ -13,7 +13,7 @@ logger = get_user_logger()
 
 def _cff_ref_to_biotools(
     ref: dict[str, Any], pub_type: list[PublicationType] | PublicationType | None = None
-) -> PublicationItem:
+) -> PublicationItem | None:
     """
     Convert a CITATION.cff reference dictionary to a bio.tools PublicationItem.
 
@@ -24,12 +24,16 @@ def _cff_ref_to_biotools(
 
     Returns
     -------
-    PublicationItem
-        The corresponding bio.tools PublicationItem.
+    PublicationItem | None
+        The corresponding bio.tools PublicationItem instance, or ``None`` if no
+        valid identifiers were found in the reference.
     """
     doi = ref.get("doi")
     pmid = ref.get("pmid")
     pmcid = ref.get("pmcid")
+
+    if not doi and not pmid and not pmcid:
+        return None
 
     pub_type_bt: list[PublicationType] | None = (
         pub_type if isinstance(pub_type, list) else [pub_type] if pub_type else None
@@ -61,6 +65,7 @@ def map_publication(
     if cff_preferred:
         gh_publications.append(_cff_ref_to_biotools(cff_preferred, pub_type=PublicationType.Primary))
     gh_publications.extend([_cff_ref_to_biotools(ref) for ref in cff_references])
+    gh_publications = [pub for pub in gh_publications if pub is not None]
 
     if not gh_publications:
         logger.unchanged("CITATION.cff exists but contains no references. Using only bio.tools metadata.")

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
@@ -1,5 +1,10 @@
 """
-Mapping functions for publication metadata from GitHub citation.cff to bio.tools.
+Mapping functions for publication metadata.
+
+This module reconciles GitHub CITATION.cff references with bio.tools
+publication entries by converting CITATION.cff data into bio.tools
+PublicationItem instances and merging them with existing entries.
+Duplicates are removed, prioritizing CITATION.cff entries.
 """
 
 from typing import Any
@@ -53,7 +58,28 @@ def map_publication(
     gh_citation_cff: dict[str, Any], bt_publications: list[PublicationItem] | None
 ) -> list[PublicationItem] | None:
     """
-    TODO
+    Map and reconcile GitHub CITATION.cff metadata and bio.tools publication entries.
+
+    Policy:
+    - If no CITATION.cff data is present, the existing bio.tools publication
+      entries are unchanged.
+    - If CITATION.cff data is present, its references are converted to
+      bio.tools PublicationItem instances and merged with existing bio.tools
+      entries. Duplicates are removed, prioritizing CITATION.cff entries.
+
+    Parameters
+    ----------
+    gh_citation_cff : dict[str, Any]
+        Parsed content of an existing CITATION.cff file from the GitHub
+        repository.
+    bt_publications : list[PublicationItem] | None
+        Existing bio.tools publication entries, or ``None`` if none are defined.
+
+    Returns
+    -------
+    list[PublicationItem] | None
+        Updated list of bio.tools publication entries after reconciliation,
+        or ``None`` if no publications are defined.
     """
     if not gh_citation_cff:
         logger.unchanged("No CITATION.cff data found in GitHub repository, nothing to map.")

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
@@ -1,0 +1,16 @@
+"""
+Mapping functions for publication metadata from GitHub citation.cff to bio.tools.
+"""
+
+from typing import Any
+
+from bridge.core.biotools import PublicationItem
+
+
+def map_publication(
+    gh_citation_cff: dict[str, Any], bt_publication: list[PublicationItem] | None
+) -> list[PublicationItem] | None:
+    """
+    TODO
+    """
+    return bt_publication

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/publication.py
@@ -4,13 +4,71 @@ Mapping functions for publication metadata from GitHub citation.cff to bio.tools
 
 from typing import Any
 
-from bridge.core.biotools import PublicationItem
+from bridge.core.biotools import PublicationItem, TypeEnum2 as PublicationType
+from bridge.logging import get_user_logger
+from bridge.pipelines.shared.publications import deduplicate_references, extract_cff_references
+
+logger = get_user_logger()
+
+
+def _cff_ref_to_biotools(
+    ref: dict[str, Any], pub_type: list[PublicationType] | PublicationType | None = None
+) -> PublicationItem:
+    """
+    Convert a CITATION.cff reference dictionary to a bio.tools PublicationItem.
+
+    Parameters
+    ----------
+    ref : dict[str, Any]
+        A single reference entry from CITATION.cff.
+
+    Returns
+    -------
+    PublicationItem
+        The corresponding bio.tools PublicationItem.
+    """
+    doi = ref.get("doi")
+    pmid = ref.get("pmid")
+    pmcid = ref.get("pmcid")
+
+    pub_type_bt: list[PublicationType] | None = (
+        pub_type if isinstance(pub_type, list) else [pub_type] if pub_type else None
+    )
+
+    return PublicationItem(
+        doi=doi,
+        pmid=pmid,
+        pmcid=pmcid,
+        type=pub_type_bt,
+        note=None,
+        version=None,
+    )
 
 
 def map_publication(
-    gh_citation_cff: dict[str, Any], bt_publication: list[PublicationItem] | None
+    gh_citation_cff: dict[str, Any], bt_publications: list[PublicationItem] | None
 ) -> list[PublicationItem] | None:
     """
     TODO
     """
-    return bt_publication
+    if not gh_citation_cff:
+        logger.unchanged("No CITATION.cff data found in GitHub repository, nothing to map.")
+        return bt_publications
+
+    cff_references, cff_preferred = extract_cff_references(gh_citation_cff)
+
+    gh_publications: list[PublicationItem] = []
+    if cff_preferred:
+        gh_publications.append(_cff_ref_to_biotools(cff_preferred, pub_type=PublicationType.Primary))
+    gh_publications.extend([_cff_ref_to_biotools(ref) for ref in cff_references])
+
+    if not gh_publications:
+        logger.unchanged("CITATION.cff exists but contains no references. Using only bio.tools metadata.")
+        return bt_publications
+
+    logger.added(f"{len(gh_publications)} reference(s) to merge with bio.tools metadata.")
+
+    all_publications = gh_publications + (bt_publications or [])
+    all_publications = deduplicate_references(all_publications)
+
+    return all_publications

--- a/src/bridge/pipelines/shared/__init__.py
+++ b/src/bridge/pipelines/shared/__init__.py
@@ -1,0 +1,3 @@
+"""
+Shared components for mapping functions across pipelines.
+"""

--- a/src/bridge/pipelines/shared/publications.py
+++ b/src/bridge/pipelines/shared/publications.py
@@ -1,0 +1,119 @@
+"""
+Shared publication utilities for pipelines.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from bridge.core import Publication
+from bridge.core.biotools import PublicationItem
+from bridge.pipelines.utils import normalize_text
+
+
+def ref_ids(ref: Publication | PublicationItem | Mapping[str, Any]) -> set[str]:
+    """
+    Extract a normalized set of identifiers for a publication-like object.
+    This function collects all available identifiers and returns
+    them as normalized strings, which can then be used for deduplication.
+
+    Supports:
+    - Europe PMC Publication model
+    - bio.tools PublicationItem model
+    - plain dict-like mappings
+
+    Normalized identifiers include (when present):
+    - DOI
+    - PMID
+    - PMCID
+    - title
+
+    Parameters
+    ----------
+    ref : Publication | Mapping[str, Any]
+        The Publication object or dictionary representing a publication.
+
+    Returns
+    -------
+    set[str]
+        A set of normalized identifier strings.
+        The set may be empty if no identifiers are present.
+
+    Raises
+    ------
+    TypeError
+        If `ref` is neither a `Publication` instance nor a mapping.
+    """
+    if isinstance(ref, Mapping):
+        doi = ref.get("doi", None)
+        pmid = ref.get("pmid", None)
+        pmcid = ref.get("pmcid", None)
+        title = ref.get("title", None)
+    elif isinstance(ref, (Publication, PublicationItem)):
+        doi = getattr(ref, "doi", None)
+        pmid = getattr(ref, "pmid", None)
+        pmcid = getattr(ref, "pmcid", None)
+        title = getattr(ref, "title", None)
+    else:
+        raise TypeError("ref must be a Publication, PublicationItem, or a Mapping")
+
+    ids: set[str] = set()
+
+    if doi:
+        ids.add(f"doi:{normalize_text(str(doi))}")
+    if pmid:
+        ids.add(f"pmid:{str(pmid).strip()}")
+    if pmcid:
+        ids.add(f"pmcid:{str(pmcid).strip()}")
+    if title:
+        ids.add(f"title:{normalize_text(str(title))}")
+
+    return ids
+
+
+def deduplicate_references(
+    references: list[Publication | PublicationItem | Mapping[str, Any]],
+) -> list[Publication | PublicationItem | Mapping[str, Any]]:
+    """
+    Deduplicate a list of publication-like objects based on shared identifiers.
+
+    Two references are considered duplicates if they share at least one
+    normalized identifier (DOI, PMID, PMCID, or title). The first occurrence
+    in the input list is retained; all later duplicates are dropped.
+
+    Parameters
+    ----------
+    references : list[Publication | Mapping[str, Any]]
+        List of references (models or dicts) to deduplicate.
+
+    Returns
+    -------
+    list[Publication | Mapping[str, Any]]
+        Deduplicated list of references, preserving original order for
+        the first occurrence of each logical publication.
+    """
+    seen_identifier_sets: list[set[str]] = []
+    deduplicated: list[Publication | PublicationItem | Mapping[str, Any]] = []
+
+    for ref in references:
+        current_ids = ref_ids(ref)
+
+        # if we have no identifiers at all, treat as unique
+        if not current_ids:
+            deduplicated.append(ref)
+            continue
+
+        duplicate = False
+        for seen_ids in seen_identifier_sets:
+            if current_ids & seen_ids:  # intersection
+                duplicate = True
+                # merge identifier sets to strengthen future matching
+                seen_ids.update(current_ids)
+                break
+
+        if duplicate:
+            continue
+
+        seen_identifier_sets.append(set(current_ids))
+        deduplicated.append(ref)
+
+    return deduplicated

--- a/src/bridge/pipelines/shared/publications.py
+++ b/src/bridge/pipelines/shared/publications.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from bridge.core import Publication
 from bridge.core.biotools import PublicationItem
-from bridge.pipelines.utils import normalize_text
+from bridge.pipelines.utils import normalize_dict_strings, normalize_text
 
 
 def ref_ids(ref: Publication | PublicationItem | Mapping[str, Any]) -> set[str]:
@@ -117,3 +117,53 @@ def deduplicate_references(
         deduplicated.append(ref)
 
     return deduplicated
+
+
+def extract_cff_references(
+    citation_cff: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """
+    Extract publication information from CITATION.cff dictionary.
+
+    This helper parses an existing CFF structure and returns:
+    - the list of reference entries, and
+    - the preferred-citation entry, if present.
+
+    The preferred citation is ensured to be part of the references list:
+    if it is not already present, it is appended.
+
+    Parameters
+    ----------
+    citation_cff : dict[str, Any] | None
+        Parsed content of an existing CITATION.cff file,
+        or ``None`` if no file exists.
+
+    Returns
+    -------
+    tuple[list[dict[str, Any]], dict[str, Any] | None]
+        A tuple of:
+        - A list of reference dictionaries extracted from the CFF.
+        - The preferred-citation dictionary, or ``None`` if not present.
+    """
+    if not citation_cff:
+        return [], None
+
+    citation_cff = normalize_dict_strings(citation_cff)
+
+    references = citation_cff.get("references") or []
+    references = [r for r in references if isinstance(r, Mapping)]
+
+    preferred = citation_cff.get("preferred-citation")
+    if isinstance(preferred, Mapping):
+        preferred = dict(preferred)  # shallow copy
+    else:
+        preferred = None
+
+    # ensure preferred-citation is included in references if present
+    if preferred is not None:
+        pref_ids = ref_ids(preferred)
+        in_refs = any(ref_ids(r) & pref_ids for r in references)
+        if not in_refs:
+            references.append(preferred)
+
+    return references, preferred


### PR DESCRIPTION
## Summary
Map publications from GitHub Citation.CFF file to bio.tools in a way that mirrors the reverse mapping.

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [ ] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #85 