### PR TITLE
add version mapping

### DIFF
--- a/src/bridge/pipelines/bt2gh_for_pr/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from bridge.pipelines.protocols import MapItem, Method, ModelsMap
 from bridge.pipelines.utils import load_dict_from_yaml_file
 
-from .map_funcs import map_citation, map_description, map_homepage, map_license, map_readme, map_topics
+from .map_funcs import map_citation, map_description, map_homepage, map_license, map_readme, map_topics, map_version
 
 
 class MapDestination(BaseModel):
@@ -24,7 +24,7 @@ class MapDestination(BaseModel):
         List of properties to be mapped to pull requests.
     """
 
-    issue: list[str] = ["description", "homepage", "topics"]
+    issue: list[str] = ["description", "homepage", "topics", "version"]
     pr: list[str] = ["citation", "readme", "license"]
 
 
@@ -48,6 +48,7 @@ class MapBioTools2GitHub(ModelsMap):
                 schema_entry=self.metadata.latest_release.tag_name,
                 repo_entry=self.repo.version,
                 method=Method.EXACT,
+                fn=map_version,
             ),
             "description": MapItem(
                 schema_entry=self.metadata.description,

--- a/src/bridge/pipelines/bt2gh_for_pr/map_funcs/version.py
+++ b/src/bridge/pipelines/bt2gh_for_pr/map_funcs/version.py
@@ -1,0 +1,21 @@
+"""
+Mapping versions from bio.tools to GitHub.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def map_version(gh_version: str | None, bt_version: list | None) -> str | None:
+    """
+    Map bio.tools version to GitHub version.
+    """
+    if not gh_version:
+        logger.info("CONFLICT: GitHub version doesn't exist.")
+        return None
+
+    if not bt_version:
+        return gh_version
+
+    return gh_version


### PR DESCRIPTION
## Summary
Added version mapping from bio.tools to GitHub. Mapped to issues if no GH version (release) is available.

## Type
- [x ] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [ ] Docs updated if needed
- [ ] Tests added/updated if needed
- [ ] Linked to an issue if applicable: Closes #ISSUE_NUMBER