### PR TITLE
Bidirectional mapping of functions

### DIFF
--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
@@ -106,7 +106,7 @@ class MapBioTools2GitHub(ModelsMap):
                     "name": self.metadata.name,
                     "biotoolsID": self.metadata.biotoolsID.root,
                     "toolType": self.metadata.toolType,
-                    "function": self.metadata.function,
+                    "functions": self.metadata.function,
                 },
                 repo_entry=self.repo.readme,
                 method=Method.FUZZY,

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
@@ -12,6 +12,7 @@ from bridge.pipelines.utils import load_dict_from_yaml_file
 from .map_funcs import (
     map_citation,
     map_description,
+    map_functions,
     map_homepage,
     map_license,
     map_name,
@@ -33,7 +34,7 @@ class MapDestination(BaseModel):
         List of properties to be mapped to pull requests.
     """
 
-    issue: list[str] = ["name", "description", "homepage", "topics", "version"]
+    issue: list[str] = ["name", "description", "homepage", "topics", "version", "functions"]
     pr: list[str] = ["citation", "readme", "license"]
 
 
@@ -115,5 +116,11 @@ class MapBioTools2GitHub(ModelsMap):
                 repo_entry=self.repo.repo.license,
                 method=Method.FUZZY,
                 fn=map_license,
+            ),
+            "functions": MapItem(
+                schema_entry=self.metadata.function,
+                repo_entry=self.repo.readme,
+                method=Method.FUZZY,
+                fn=map_functions,
             ),
         }

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map.py
@@ -106,6 +106,7 @@ class MapBioTools2GitHub(ModelsMap):
                     "name": self.metadata.name,
                     "biotoolsID": self.metadata.biotoolsID.root,
                     "toolType": self.metadata.toolType,
+                    "function": self.metadata.function,
                 },
                 repo_entry=self.repo.readme,
                 method=Method.FUZZY,

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/__init__.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/__init__.py
@@ -4,6 +4,7 @@ Individual mapping functions for bio.tools to GitHub.
 
 from .citation import map_citation
 from .description import map_description
+from .functions import map_functions
 from .homepage import map_homepage
 from .license import map_license
 from .name import map_name
@@ -20,4 +21,5 @@ __all__ = [
     "map_license",
     "map_version",
     "map_name",
+    "map_functions",
 ]

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -120,8 +120,26 @@ def _build_functions(functions: list[FunctionItem]) -> str:
     str
         The concatenated function strings.
     """
-    txt = "# Functions\n\n"
-    return txt + "\n".join(_build_function(function) for function in functions)
+    return "\n".join(_build_function(function) for function in functions)
+
+
+def _build_functions_section(functions: list[FunctionItem]) -> str:
+    """
+    Build a string for all functions by concatenating the built function strings
+    and adding a section header.
+
+    Parameters
+    ----------
+    functions : list[FunctionItem]
+        The list of FunctionItems to build.
+
+    Returns
+    -------
+    str
+        The concatenated function strings.
+    """
+    txt = "# Functions\n"
+    return txt + _build_functions(functions)
 
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> dict[str, str] | None:
@@ -159,13 +177,13 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         logger.info("No functions found in biotools, no issue needed.")
         return None
 
-    functions_txt = _build_functions(bt_functions)
+    functions_txt = _build_functions_section(bt_functions)
     issue_body = (
         "The bio.tools metadata contains the following function annotations, "
-        "but they are not mentioned in the GitHub README:\n"
+        "but they are not mentioned in the GitHub README.\n"
         "Please consider adding these functions to the README to improve discoverability "
         "and provide users with more information about the tool's capabilities.\n\n"
-        f"```\n{functions_txt}\n```"
+        f"~~~markdown\n{functions_txt}\n~~~"
     )
     logger.added("bio.tools function annotations added to issue.")
     return {"Add function annotations from bio.tools metadata": issue_body}
@@ -205,7 +223,8 @@ def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionIt
         return gh_readme
 
     matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
-    functions_in_readme = len(matches) > 0
+    matches_blocks = [m.group(0) for m in matches]
+    functions_in_readme = len(matches_blocks) > 0
     if not functions_in_readme:
         logger.info("Functions are not mentioned in the README, no PR needed.")
         return gh_readme
@@ -214,7 +233,6 @@ def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionIt
         logger.info("No functions found in biotools, no need to include any in README.")
         return gh_readme
 
-    matches_blocks = [m.group(0) for m in matches]
     before, after = separate_snippets_from_text(gh_readme, matches_blocks)
     functions_txt = _build_functions(bt_functions)
     new_readme = before + functions_txt + after

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -30,14 +30,14 @@ FUNCTION_TEMPLATE = """
 FUNCTION_PATTERN = re.compile(
     r"""
     <details>\s*
-    <summary>(?P<name>.*?)</summary>\s*
-    ```yaml\s*
-    #\s*biotools-function\s*
+    <summary>(?P<name>[^\n<]*)</summary>\s*
+    ```yaml[ \t]*\n
+    #[ \t]*biotools-function[ \t]*\n
     (?P<yaml>.*?)
-    ```\s*
-    </details>
+    ^```[ \t]*\n
+    \s*</details>
     """,
-    re.DOTALL | re.VERBOSE,
+    re.DOTALL | re.VERBOSE | re.MULTILINE,
 )
 
 
@@ -78,9 +78,7 @@ def _build_function_name(function: FunctionItem) -> str:
     str
         The built function name.
     """
-    operations = function.operation  # min 1
-    operations_str = ", ".join(op.term for op in operations)
-    return operations_str
+    return ", ".join((op.term or op.uri or "Unnamed operation").strip() for op in function.operation)
 
 
 def _build_function(function: FunctionItem) -> str:

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -120,7 +120,7 @@ def _build_functions(functions: list[FunctionItem]) -> str:
     str
         The concatenated function strings.
     """
-    txt = "#Functions\n\n"
+    txt = "# Functions\n\n"
     return txt + "\n".join(_build_function(function) for function in functions)
 
 
@@ -165,7 +165,7 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         "but they are not mentioned in the GitHub README:\n"
         "Please consider adding these functions to the README to improve discoverability "
         "and provide users with more information about the tool's capabilities.\n\n"
-        f"{functions_txt}"
+        f"```\n{functions_txt}\n```"
     )
     logger.added("bio.tools function annotations added to issue.")
     return {"Add function annotations from bio.tools metadata": issue_body}

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -6,6 +6,8 @@ GitHub README and, when appropriate, proposes a GitHub issue suggesting that
 the bio.tools function annotations be added to the README.
 """
 
+import re
+
 import yaml
 
 from bridge.core.biotools import FunctionItem
@@ -14,7 +16,6 @@ from bridge.pipelines.utils import fill_template
 
 logger = get_user_logger()
 
-BIOTOOLS_MARKER = "# biotools-function"
 FUNCTION_TEMPLATE = """
 <details>
 <summary>{{ FUNCTION_NAME }}</summary>
@@ -26,6 +27,18 @@ FUNCTION_TEMPLATE = """
 
 </details>
 """
+FUNCTION_PATTERN = re.compile(
+    r"""
+    <details>\s*
+    <summary>(?P<name>.*?)</summary>\s*
+    ```yaml\s*
+    #\s*biotools-function\s*
+    (?P<yaml>.*?)
+    ```\s*
+    </details>
+    """,
+    re.DOTALL | re.VERBOSE,
+)
 
 
 def _function_to_yaml(function: FunctionItem) -> str:
@@ -116,7 +129,7 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
     Propose a GitHub issue to add function annotations based on bio.tools metadata.
 
     Steps performed:
-    1. Check if the README already mentions functions using the BIOTOOLS_MARKER.
+    1. Check if the README already mentions functions using the FUNCTION_PATTERN.
        If it does, no issue is needed.
     2. If no functions are found in bio.tools, no issue is needed.
     3. If functions are present in bio.tools but not mentioned in the README, build
@@ -136,7 +149,8 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         A dictionary with the issue title as key and the issue body as value,
         or ``None`` if no issue is to be created.
     """
-    functions_in_readme = BIOTOOLS_MARKER in (gh_readme or "")
+    matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
+    functions_in_readme = len(matches) > 0
     if functions_in_readme:
         logger.info("Functions are mentioned in the README, no issue needed.")
         return None

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -1,0 +1,33 @@
+"""
+Docstring for bridge.pipelines.bt2gh_for_pr_issues.map_funcs.functions
+"""
+
+from bridge.core.biotools import FunctionItem
+from bridge.logging import get_user_logger
+
+logger = get_user_logger()
+
+FUNCTION_TEMPLATE = """
+<details>
+<summary>{{ FUNCTION_NAME }}</summary>
+
+```yaml
+# biotools-function
+{{ FUNCTION_YAML}}
+```
+
+</details>
+"""
+
+
+def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> dict[str, str] | None:
+    """
+    Docstring for map_functions
+    """
+    functions_in_readme = False
+    # TODO: check if the functions are actually mentioned in the README
+    if functions_in_readme:
+        logger.info("Functions are mentioned in the README, no issue needed.")
+        return None
+
+    return None

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -30,11 +30,11 @@ FUNCTION_TEMPLATE = """
 FUNCTION_PATTERN = re.compile(
     r"""
     <details>\s*
-    <summary>(?P<name>[^\n<]*)</summary>\s*
-    ```yaml[ \t]*\n
-    #[ \t]*biotools-function[ \t]*\n
+    <summary>(?P<name>[^\r\n<]*)</summary>\s*
+    ```yaml[ \t]*\r?\n
+    #[ \t]*biotools-function[ \t]*\r?\n
     (?P<yaml>.*?)
-    ^```[ \t]*\n
+    ^[ \t]*```[ \t]*\r?\n
     \s*</details>
     """,
     re.DOTALL | re.VERBOSE | re.MULTILINE,

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -204,6 +204,10 @@ def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionIt
         The new function blocks are built using the FUNCTION_TEMPLATE and the
         function data from bio.tools.
 
+    This function is intended to be used in the construction of a README update for a PR,
+    where the updated README content is proposed directly rather than suggesting the update via an issue.
+    See `readme` module for the usage of this function in the context of a README update.
+
     Parameters
     ----------
     gh_readme : str | None

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -122,10 +122,10 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
 
     functions_txt = _build_functions(bt_functions)
     issue_body = (
-        "The bio.tools metadata contains the following function annotations, ",
-        "but they are not mentioned in the GitHub README:\n",
-        "Please consider adding these functions to the README to improve discoverability ",
-        "and provide users with more information about the tool's capabilities.\n\n",
-        f"{functions_txt}",
+        "The bio.tools metadata contains the following function annotations, "
+        "but they are not mentioned in the GitHub README:\n"
+        "Please consider adding these functions to the README to improve discoverability "
+        "and provide users with more information about the tool's capabilities.\n\n"
+        f"{functions_txt}"
     )
     return {"Add function annotations from bio.tools metadata": issue_body}

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -2,8 +2,11 @@
 Docstring for bridge.pipelines.bt2gh_for_pr_issues.map_funcs.functions
 """
 
+import yaml
+
 from bridge.core.biotools import FunctionItem
 from bridge.logging import get_user_logger
+from bridge.pipelines.utils import fill_template
 
 logger = get_user_logger()
 
@@ -20,6 +23,89 @@ FUNCTION_TEMPLATE = """
 """
 
 
+def _function_to_yaml(function: FunctionItem) -> str:
+    """
+    Convert a FunctionItem to a YAML string.
+
+    Parameters
+    ----------
+    function : FunctionItem
+        The FunctionItem to convert.
+
+    Returns
+    -------
+    str
+        The YAML string representation of the FunctionItem.
+    """
+    data = function.model_dump(exclude_none=True)
+    return yaml.safe_dump(
+        data,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+    )
+
+
+def _build_function_name(function: FunctionItem) -> str:
+    """
+    Build a function name out of the function's operations.
+
+    Parameters
+    ----------
+    function : FunctionItem
+        The FunctionItem to build the name from.
+
+    Returns
+    -------
+    str
+        The built function name.
+    """
+    operations = function.operation  # min 1
+    operations_str = ", ".join(op.term for op in operations)
+    return operations_str
+
+
+def _build_function(function: FunctionItem) -> str:
+    """
+    Build a function string by converting the FunctionItem to YAML and filling the FUNCTION_TEMPLATE.
+
+    Parameters
+    ----------
+    function : FunctionItem
+        The function item to build.
+
+    Returns
+    -------
+    str
+        The built function string.
+    """
+    function_yaml = _function_to_yaml(function)
+    function_name = _build_function_name(function)
+    filling = {
+        "FUNCTION_NAME": function_name,
+        "FUNCTION_YAML": function_yaml,
+    }
+    return fill_template(FUNCTION_TEMPLATE, filling)
+
+
+def _build_functions(functions: list[FunctionItem]) -> str:
+    """
+    Build a string for all functions by concatenating the built function strings.
+
+    Parameters
+    ----------
+    functions : list[FunctionItem]
+        The list of FunctionItems to build.
+
+    Returns
+    -------
+    str
+        The concatenated function strings.
+    """
+    txt = "#Functions\n\n"
+    return txt + "\n".join(_build_function(function) for function in functions)
+
+
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> dict[str, str] | None:
     """
     Docstring for map_functions
@@ -30,4 +116,16 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         logger.info("Functions are mentioned in the README, no issue needed.")
         return None
 
-    return None
+    if not bt_functions:
+        logger.info("No functions found in biotools, no issue needed.")
+        return None
+
+    functions_txt = _build_functions(bt_functions)
+    issue_body = (
+        "The bio.tools metadata contains the following function annotations, ",
+        "but they are not mentioned in the GitHub README:\n",
+        "Please consider adding these functions to the README to improve discoverability ",
+        "and provide users with more information about the tool's capabilities.\n\n",
+        f"{functions_txt}",
+    )
+    return {"Add function annotations from bio.tools metadata": issue_body}

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -197,21 +197,22 @@ def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionIt
     Returns
     -------
     str | None
-        The updated README content with function annotations added, or ``None`` if no update is needed.
+        The updated README content with function annotations added,
+        or the original README content if no update is needed.
     """
     if gh_readme is None:
         logger.info("README does not exist, no need to map functions.")
-        return None
+        return gh_readme
 
     matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
     functions_in_readme = len(matches) > 0
     if not functions_in_readme:
         logger.info("Functions are not mentioned in the README, no PR needed.")
-        return None
+        return gh_readme
 
     if not bt_functions:
         logger.info("No functions found in biotools, no need to include any in README.")
-        return None
+        return gh_readme
 
     matches_blocks = [m.group(0) for m in matches]
     before, after = separate_snippets_from_text(gh_readme, matches_blocks)

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -6,12 +6,11 @@ GitHub README and, when appropriate, proposes a GitHub issue suggesting that
 the bio.tools function annotations be added to the README.
 """
 
-import re
-
 import yaml
 
 from bridge.core.biotools import FunctionItem
 from bridge.logging import get_user_logger
+from bridge.pipelines.shared.functions import find_matches
 from bridge.pipelines.utils import fill_template, separate_snippets_from_text
 
 logger = get_user_logger()
@@ -27,18 +26,6 @@ FUNCTION_TEMPLATE = """
 
 </details>
 """
-FUNCTION_PATTERN = re.compile(
-    r"""
-    <details>\s*
-    <summary>(?P<name>[^\r\n<]*)</summary>\s*
-    ```yaml[ \t]*\r?\n
-    #[ \t]*biotools-function[ \t]*\r?\n
-    (?P<yaml>.*?)
-    ^[ \t]*```[ \t]*\r?\n
-    \s*</details>
-    """,
-    re.DOTALL | re.VERBOSE | re.MULTILINE,
-)
 
 
 def _function_to_yaml(function: FunctionItem) -> str:
@@ -165,7 +152,7 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         A dictionary with the issue title as key and the issue body as value,
         or ``None`` if no issue is to be created.
     """
-    matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
+    matches = find_matches(gh_readme)
     functions_in_readme = len(matches) > 0
     if functions_in_readme:
         logger.info("Functions are mentioned in the README, no issue needed.")
@@ -224,7 +211,7 @@ def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionIt
         logger.info("README does not exist, no need to map functions.")
         return gh_readme
 
-    matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
+    matches = find_matches(gh_readme)
     matches_blocks = [m.group(0) for m in matches]
     functions_in_readme = len(matches_blocks) > 0
     if not functions_in_readme:

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -12,7 +12,7 @@ import yaml
 
 from bridge.core.biotools import FunctionItem
 from bridge.logging import get_user_logger
-from bridge.pipelines.utils import fill_template
+from bridge.pipelines.utils import fill_template, separate_snippets_from_text
 
 logger = get_user_logger()
 
@@ -169,3 +169,53 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
     )
     logger.added("bio.tools function annotations added to issue.")
     return {"Add function annotations from bio.tools metadata": issue_body}
+
+
+def map_functions_to_readme(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> str | None:
+    """
+    Propose an updated README content by adding function annotations from bio.tools metadata.
+
+    Steps performed:
+    1. Check if README exists; if not, no update is needed.
+    2. Check if the README already mentions functions using the FUNCTION_PATTERN.
+       If it does not, no update is needed.
+    3. If no functions are found in bio.tools, no update is needed.
+    4. If functions are present in bio.tools and the README mentions functions,
+         remove all existing function blocks from the README.
+    5. In their place, add new function blocks for each function from bio.tools.
+        The new function blocks are built using the FUNCTION_TEMPLATE and the
+        function data from bio.tools.
+
+    Parameters
+    ----------
+    gh_readme : str | None
+        The current README content from GitHub, or ``None`` if the file does
+        not exist yet.
+    bt_functions : list[FunctionItem] | None
+        The list of FunctionItems from bio.tools metadata, or ``None`` if no functions are defined.
+
+    Returns
+    -------
+    str | None
+        The updated README content with function annotations added, or ``None`` if no update is needed.
+    """
+    if gh_readme is None:
+        logger.info("README does not exist, no need to map functions.")
+        return None
+
+    matches = list(FUNCTION_PATTERN.finditer(gh_readme or ""))
+    functions_in_readme = len(matches) > 0
+    if not functions_in_readme:
+        logger.info("Functions are not mentioned in the README, no PR needed.")
+        return None
+
+    if not bt_functions:
+        logger.info("No functions found in biotools, no need to include any in README.")
+        return None
+
+    matches_blocks = [m.group(0) for m in matches]
+    before, after = separate_snippets_from_text(gh_readme, matches_blocks)
+    functions_txt = _build_functions(bt_functions)
+    new_readme = before + functions_txt + after
+    logger.added("bio.tools function annotations added to README content.")
+    return new_readme

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/functions.py
@@ -1,5 +1,9 @@
 """
-Docstring for bridge.pipelines.bt2gh_for_pr_issues.map_funcs.functions
+Map function annotations from bio.tools to GitHub.
+
+This module compares the function annotations recorded in bio.tools with the
+GitHub README and, when appropriate, proposes a GitHub issue suggesting that
+the bio.tools function annotations be added to the README.
 """
 
 import yaml
@@ -10,6 +14,7 @@ from bridge.pipelines.utils import fill_template
 
 logger = get_user_logger()
 
+BIOTOOLS_MARKER = "# biotools-function"
 FUNCTION_TEMPLATE = """
 <details>
 <summary>{{ FUNCTION_NAME }}</summary>
@@ -108,10 +113,30 @@ def _build_functions(functions: list[FunctionItem]) -> str:
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> dict[str, str] | None:
     """
-    Docstring for map_functions
+    Propose a GitHub issue to add function annotations based on bio.tools metadata.
+
+    Steps performed:
+    1. Check if the README already mentions functions using the BIOTOOLS_MARKER.
+       If it does, no issue is needed.
+    2. If no functions are found in bio.tools, no issue is needed.
+    3. If functions are present in bio.tools but not mentioned in the README, build
+         a function string for each function and propose an issue to add them to the README.
+
+    Parameters
+    ----------
+    gh_readme : str | None
+        The current README content from GitHub, or ``None`` if the file does
+        not exist yet.
+    bt_functions : list[FunctionItem] | None
+        The list of FunctionItems from bio.tools metadata, or ``None`` if no functions are defined.
+
+    Returns
+    -------
+    dict[str, str] | None
+        A dictionary with the issue title as key and the issue body as value,
+        or ``None`` if no issue is to be created.
     """
-    functions_in_readme = False
-    # TODO: check if the functions are actually mentioned in the README
+    functions_in_readme = BIOTOOLS_MARKER in (gh_readme or "")
     if functions_in_readme:
         logger.info("Functions are mentioned in the README, no issue needed.")
         return None
@@ -128,4 +153,5 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
         "and provide users with more information about the tool's capabilities.\n\n"
         f"{functions_txt}"
     )
+    logger.added("bio.tools function annotations added to issue.")
     return {"Add function annotations from bio.tools metadata": issue_body}

--- a/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/readme.py
+++ b/src/bridge/pipelines/bt2gh_for_pr_issues/map_funcs/readme.py
@@ -15,7 +15,7 @@ import re
 from collections.abc import Iterable
 from typing import Any
 
-from bridge.core.biotools import ToolTypeEnum
+from bridge.core.biotools import FunctionItem, ToolTypeEnum
 from bridge.logging import get_user_logger
 from bridge.pipelines.utils import (
     Badge,
@@ -23,6 +23,8 @@ from bridge.pipelines.utils import (
     fill_template,
     remove_first_snippet_from_text,
 )
+
+from .functions import map_functions_to_readme
 
 logger = get_user_logger()
 
@@ -220,7 +222,13 @@ def _extract_project_title(gh_readme: str | None) -> str | None:
     return None
 
 
-def _build_readme(gh_readme: str | None, bt_name: str, bt_id: str, bt_tool_types: list[ToolTypeEnum] | None) -> str:
+def _build_readme(
+    gh_readme: str | None,
+    bt_name: str,
+    bt_id: str,
+    bt_tool_types: list[ToolTypeEnum] | None,
+    bt_functions: list[FunctionItem] | None,
+) -> str:
     """
     Construct an updated README from existing content and bio.tools metadata.
 
@@ -237,7 +245,8 @@ def _build_readme(gh_readme: str | None, bt_name: str, bt_id: str, bt_tool_types
        '# <bt_name>' as the title.
     5. Strips the original title and badges from the README to obtain the
        remaining content body.
-    6. Renders a new README using a simple template that places the title, badges,
+    6. Adds function annotations from bio.tools to the content body.
+    7. Renders a new README using a simple template that places the title, badges,
        and remaining content in order.
 
     Parameters
@@ -250,6 +259,9 @@ def _build_readme(gh_readme: str | None, bt_name: str, bt_id: str, bt_tool_types
         The `biotoolsID` of the tool from bio.tools metadata.
     bt_tool_types : list[ToolTypeEnum] | None
         A list of tool types (`toolType` field from bio.tools), or ``None``
+        if not available or not valid.
+    bt_functions : list[FunctionItem] | None
+        A list of function items (`functions` field from bio.tools), or ``None``
         if not available or not valid.
 
     Returns
@@ -311,6 +323,9 @@ def _build_readme(gh_readme: str | None, bt_name: str, bt_id: str, bt_tool_types
         lines.pop(0)
     content = "\n".join(lines)
 
+    # add functions to content
+    content = map_functions_to_readme(content, bt_functions)
+
     # compose final README
     placeholders = {
         "TITLE": title,
@@ -345,6 +360,7 @@ def map_readme(gh_readme: str | None, bt_params: dict[str, Any]) -> dict[str, st
         - 'name'       : Name of the tool.
         - 'biotoolsID' : bio.tools identifier of the tool.
         - 'toolType'   : Optional list of tool types (typically `ToolTypeEnum`).
+        - 'functions' : Optional list of function items (typically `FunctionItem`).
 
     Returns
     -------
@@ -360,6 +376,7 @@ def map_readme(gh_readme: str | None, bt_params: dict[str, Any]) -> dict[str, st
     bt_name = bt_params.get("name", None)
     bt_id = bt_params.get("biotoolsID", None)
     bt_tool_types = bt_params.get("toolType", None)
+    bt_functions = bt_params.get("functions", None)
 
     if bt_name is None:
         raise ValueError("bt_params must contain 'name' field.")
@@ -373,7 +390,7 @@ def map_readme(gh_readme: str | None, bt_params: dict[str, Any]) -> dict[str, st
     ):
         bt_tool_types = None
 
-    gh_readme_updated = _build_readme(gh_readme, bt_name, bt_id, bt_tool_types)
+    gh_readme_updated = _build_readme(gh_readme, bt_name, bt_id, bt_tool_types, bt_functions)
 
     if gh_readme == gh_readme_updated:
         logger.unchanged("README.md remains unchanged.")

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -70,6 +70,7 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         version=await mapper.map["version"].run(),
         documentation=await mapper.map["documentation"].run(),
         publication=await mapper.map["publication"].run(),
+        function=await mapper.map["functions"].run(),
     )
 
     biotools_url = settings.biotools_url

--- a/src/bridge/pipelines/gh2bt_for_meta/map.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map.py
@@ -11,6 +11,7 @@ from .map_funcs import (
     map_biotools_id,
     map_description,
     map_documentation,
+    map_functions,
     map_homepage,
     map_language,
     map_license,
@@ -111,5 +112,11 @@ class MapGitHub2BioTools(ModelsMap):
                 repo_entry=load_dict_from_yaml_file(self.repo_path / "CITATION.cff"),
                 method=Method.FUZZY,
                 fn=map_publication,
+            ),
+            "functions": MapItem(
+                schema_entry=self.metadata.function,
+                repo_entry=self.repo.readme,
+                method=Method.FUZZY,
+                fn=map_functions,
             ),
         }

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/__init__.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/__init__.py
@@ -5,6 +5,7 @@ Individual mapping functions for GitHub to bio.tools.
 from .biotools_id import map_biotools_id
 from .description import map_description
 from .documentation import map_documentation
+from .functions import map_functions
 from .homepage import map_homepage
 from .language import map_language
 from .license import map_license
@@ -24,4 +25,5 @@ __all__ = [
     "map_publication",
     "map_name",
     "map_biotools_id",
+    "map_functions",
 ]

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/biotools_id.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/biotools_id.py
@@ -9,6 +9,7 @@ within bio.tools, generating alternative IDs if necessary.
 import httpx
 
 from bridge.builders import compose_biotools_metadata
+from bridge.core.biotools import BiotoolsIdType
 from bridge.logging import get_user_logger
 from bridge.pipelines.utils import normalize_text, str_contain_each_other
 
@@ -46,7 +47,7 @@ async def _matching_biotools_id_exists(biotools_id: str) -> bool:
     return matching_bt_metadata is not None
 
 
-async def map_biotools_id(gh_name: str | None, bt_id: str | None) -> str | None:
+async def map_biotools_id(gh_name: str | None, bt_id: BiotoolsIdType | None) -> str | None:
     """
     Map and reconcile GitHub repository name to bio.tools ID.
 
@@ -67,12 +68,12 @@ async def map_biotools_id(gh_name: str | None, bt_id: str | None) -> str | None:
     ----------
     gh_name : str | None
         GitHub repository name.
-    bt_id : str | None
+    bt_id : BiotoolsIdType | None
         Existing bio.tools ID.
 
     Returns
     -------
-    str | None
+    BiotoolsIdType | None
         Mapped bio.tools ID, or ``None`` if mapping failed.
     """
     if gh_name is None:
@@ -80,7 +81,7 @@ async def map_biotools_id(gh_name: str | None, bt_id: str | None) -> str | None:
         return bt_id
 
     gh_norm = normalize_text(gh_name)
-    bt_norm = normalize_text(bt_id or "")
+    bt_norm = normalize_text(bt_id.root if bt_id is not None else "")
 
     if bt_id is not None and str_contain_each_other(gh_norm, bt_norm):
         logger.exact(f"bio.tools ID '{bt_id}' and GitHub repo name '{gh_name}' contain each other")
@@ -91,7 +92,7 @@ async def map_biotools_id(gh_name: str | None, bt_id: str | None) -> str | None:
 
     if not await _matching_biotools_id_exists(gh_norm):
         logger.added(f"Using GitHub repo name '{gh_name}' as bio.tools ID")
-        return gh_norm
+        return BiotoolsIdType(gh_norm)
 
     logger.conflict(
         f"GitHub repo name '{gh_name}' cannot be used as bio.tools ID because it matches an existing entry. "
@@ -102,7 +103,7 @@ async def map_biotools_id(gh_name: str | None, bt_id: str | None) -> str | None:
         candidate_id = f"{gh_norm}-{suffix}"
         if not await _matching_biotools_id_exists(candidate_id):
             logger.added(f"Using generated bio.tools ID '{candidate_id}'")
-            return candidate_id
+            return BiotoolsIdType(candidate_id)
 
     logger.note(
         f"Failed to generate unique bio.tools ID based on GitHub repo name '{gh_name}'. "

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -3,10 +3,22 @@ Docstring for bridge.pipelines.gh2bt_for_meta.map_funcs.functions
 """
 
 from bridge.core.biotools import FunctionItem
+from bridge.pipelines.policies.gh2bt import reconcile_gh_ontop_bt
+
+
+def _extract_functions_from_readme(gh_readme: str) -> set[FunctionItem] | None:
+    return None
 
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> list[FunctionItem] | None:
     """
     Docstring for map_functions
     """
-    return None
+    return reconcile_gh_ontop_bt(
+        gh_norm=gh_readme,
+        bt_norm=set(bt_functions) if bt_functions is not None else None,
+        bt_value=bt_functions,
+        build_bt_from_gh=_extract_functions_from_readme,
+        build_bt_from_norm=lambda bt_norm: set(bt_norm) if bt_norm is not None else None,
+        log_label="functions",
+    )

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -2,31 +2,170 @@
 Docstring for bridge.pipelines.gh2bt_for_meta.map_funcs.functions
 """
 
+import json
+from typing import Any
+
 import yaml
 
 from bridge.core.biotools import FunctionItem
 from bridge.logging import get_user_logger
 from bridge.pipelines.policies.gh2bt import reconcile_gh_ontop_bt
 from bridge.pipelines.shared.functions import find_match_yamls
+from bridge.pipelines.utils import normalize_dict_strings, object_to_primitive
 
 logger = get_user_logger()
 
 
-def _extract_functions_from_readme(gh_readme: str | None) -> set[FunctionItem] | None:
+def _stable_json(x: Any) -> str:
+    """
+    Convert a Python object to a JSON string with stable key ordering and compact formatting.
+    This is useful for creating consistent string representations of
+    complex objects (e.g., functions) for hashing or comparison.
+
+    Parameters
+    ----------
+    x : Any
+        The Python object to convert to a stable JSON string.
+
+    Returns
+    -------
+    str
+        The stable JSON string representation of the input object.
+    """
+    return json.dumps(x, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _sort_list_of_dicts(lst: list[Any]) -> list[Any]:
+    """
+    Sort a list of dictionaries by their stable JSON representation to ensure consistent ordering.
+    This is used to canonicalize lists where order is not semantically meaningful.
+
+    Parameters
+    ----------
+    lst : list[Any]
+        The list of dictionaries to sort.
+
+    Returns
+    -------
+    list[Any]
+        A new list sorted by the stable JSON representation of its dictionary elements.
+    """
+    return sorted(lst, key=_stable_json)
+
+
+def _canonicalize_function_payload(d: dict[str, Any]) -> dict[str, Any]:
+    """
+    Make semantically-equivalent FunctionItems produce identical packed keys.
+    This involves sorting lists of dictionaries (e.g., operations, inputs, outputs)
+    to ensure that different orderings of the same content yield the same representation.
+
+    Parameters
+    ----------
+    d : dict[str, Any]
+        The dictionary representation of a FunctionItem to canonicalize.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new dictionary with sorted lists to ensure consistent representation of semantically equivalent FunctionItems.
+    """
+    d = dict(d)
+
+    if isinstance(d.get("operation"), list):
+        d["operation"] = _sort_list_of_dicts(d["operation"])
+
+    for k in ("input", "output"):
+        items = d.get(k)
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and isinstance(item.get("format"), list):
+                    item["format"] = _sort_list_of_dicts(item["format"])
+            d[k] = _sort_list_of_dicts(items)
+
+    return d
+
+
+def _pack_function_item(fi: FunctionItem, *, ignore_free_text: bool = False) -> str:
+    """
+    Return a hashable packed representation of a FunctionItem by
+    converting it to a primitive dict, canonicalizing it, and then to a stable JSON string.
+
+    Parameters
+    ----------
+    fi : FunctionItem
+        The FunctionItem to pack.
+    ignore_free_text : bool, optional
+        Whether to ignore free-text fields like "note" and "cmd" in the packing process
+        (default is ``False``).
+
+    Returns
+    -------
+    str
+        A stable JSON string representation of the FunctionItem that can be used for hashing or comparison.
+    """
+    prim = object_to_primitive(fi)
+    prim = normalize_dict_strings(prim)
+
+    if ignore_free_text:
+        prim.pop("note", None)
+        prim.pop("cmd", None)
+
+    prim = _canonicalize_function_payload(prim)
+    return _stable_json(prim)
+
+
+def _unpack_function_item(packed: str) -> FunctionItem:
+    """
+    Unpack a FunctionItem from its packed JSON string representation.
+
+    Parameters
+    ----------
+    packed : str
+        The packed JSON string representation of a FunctionItem.
+
+    Returns
+    -------
+    FunctionItem
+        The unpacked FunctionItem reconstructed from the JSON string.
+    """
+    return FunctionItem(**json.loads(packed))
+
+
+def _extract_functions_from_readme(gh_readme: str | None) -> set[str] | None:
+    """
+    Extract function annotations from the GitHub README by finding all YAML blocks
+    that match the function annotation pattern, parsing them into FunctionItems,
+    and returning a set of their packed representations for comparison.
+
+    Parameters
+    ----------
+    gh_readme : str | None
+        The content of the GitHub README to extract function annotations from.
+
+    Returns
+    -------
+    set[str] | None
+        A set of packed FunctionItem representations extracted from the README, or ``None`` if no
+        function annotations are found.
+    """
     yamls = find_match_yamls(gh_readme)
-    # Parse YAMLs into FunctionItems
-    functions = set()
+
+    function_keys = set()
     for yaml_str in yamls:
         try:
             data = yaml.safe_load(yaml_str)
-            if isinstance(data, dict):
-                function_item = FunctionItem.from_dict(data)
-                functions.add(function_item)
-            else:
+            if not isinstance(data, dict):
                 logger.warning("YAML block is not a dictionary, skipping: %s", yaml_str)
+                continue
+
+            function_item = FunctionItem(**data)
+            key = _pack_function_item(function_item, ignore_free_text=False)
+            function_keys.add(key)
+
         except yaml.YAMLError as e:
             logger.warning("Failed to parse YAML block, skipping: %s\nError: %s", yaml_str, e)
-    return functions if functions else None
+
+    return function_keys or None
 
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> list[FunctionItem] | None:

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -1,5 +1,12 @@
 """
-Docstring for bridge.pipelines.gh2bt_for_meta.map_funcs.functions
+Map function annotations from GitHub to bio.tools.
+
+This modules reconciles the function annotations recorded in the GitHub README and
+existing bio.tools metadata, and produces a reconciled list of `FunctionItem` instances
+to be included in the bio.tools metadata. The reconciliation is performed using the
+generic bio.tools-on-top-of-GitHub policy, which preserves existing bio.tools annotations
+unless the GitHub README contains explicit function annotations that differ from bio.tools,
+in which case the GitHub annotations are added on top of the existing bio.tools ones.
 """
 
 import json
@@ -170,7 +177,25 @@ def _extract_functions_from_readme(gh_readme: str | None) -> set[str] | None:
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> list[FunctionItem] | None:
     """
-    Docstring for map_functions
+    Map and reconcile GitHub and bio.tools function annotations using the generic
+    bio.tools-on-top-of-GitHub policy with canonicalization.
+
+    Function comparison is performed on the packed representations of FunctionItems,
+    which are designed to yield identical keys for semantically equivalent functions
+    regardless of ordering or free-text differences.
+
+    Parameters
+    ----------
+    gh_readme : str | None
+        The current README content from GitHub, or ``None`` if the file does not exist yet.
+    bt_functions : list[FunctionItem] | None
+        The list of `FunctionItem` instances from bio.tools metadata, or ``None`` if no functions are defined.
+
+    Returns
+    -------
+    list[FunctionItem] | None
+        The reconciled list of `FunctionItem` instances to be used in bio.tools metadata,
+        or ``None`` if no functions should be included.
     """
     bt_norm = (
         {_pack_function_item(fi, ignore_free_text=False) for fi in bt_functions} if bt_functions is not None else None

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -172,11 +172,18 @@ def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None
     """
     Docstring for map_functions
     """
+    bt_norm = (
+        {_pack_function_item(fi, ignore_free_text=False) for fi in bt_functions} if bt_functions is not None else None
+    )
+
+    def build_bt_from_norm(fi_keys):
+        return [_unpack_function_item(fi) for fi in fi_keys] if fi_keys is not None else None
+
     return reconcile_gh_ontop_bt(
         gh_norm=gh_readme,
-        bt_norm=set(bt_functions) if bt_functions is not None else None,
+        bt_norm=bt_norm,
         bt_value=bt_functions,
         build_bt_from_gh=_extract_functions_from_readme,
-        build_bt_from_norm=lambda bt_norm: set(bt_norm) if bt_norm is not None else None,
+        build_bt_from_norm=build_bt_from_norm,
         log_label="functions",
     )

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -1,0 +1,12 @@
+"""
+Docstring for bridge.pipelines.gh2bt_for_meta.map_funcs.functions
+"""
+
+from bridge.core.biotools import FunctionItem
+
+
+def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> list[FunctionItem] | None:
+    """
+    Docstring for map_functions
+    """
+    return None

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/functions.py
@@ -2,12 +2,31 @@
 Docstring for bridge.pipelines.gh2bt_for_meta.map_funcs.functions
 """
 
+import yaml
+
 from bridge.core.biotools import FunctionItem
+from bridge.logging import get_user_logger
 from bridge.pipelines.policies.gh2bt import reconcile_gh_ontop_bt
+from bridge.pipelines.shared.functions import find_match_yamls
+
+logger = get_user_logger()
 
 
-def _extract_functions_from_readme(gh_readme: str) -> set[FunctionItem] | None:
-    return None
+def _extract_functions_from_readme(gh_readme: str | None) -> set[FunctionItem] | None:
+    yamls = find_match_yamls(gh_readme)
+    # Parse YAMLs into FunctionItems
+    functions = set()
+    for yaml_str in yamls:
+        try:
+            data = yaml.safe_load(yaml_str)
+            if isinstance(data, dict):
+                function_item = FunctionItem.from_dict(data)
+                functions.add(function_item)
+            else:
+                logger.warning("YAML block is not a dictionary, skipping: %s", yaml_str)
+        except yaml.YAMLError as e:
+            logger.warning("Failed to parse YAML block, skipping: %s\nError: %s", yaml_str, e)
+    return functions if functions else None
 
 
 def map_functions(gh_readme: str | None, bt_functions: list[FunctionItem] | None) -> list[FunctionItem] | None:

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/language.py
@@ -11,7 +11,7 @@ discrepancies are found.
 from bridge.core.biotools import LanguageEnum
 from bridge.core.github_languages import Language
 from bridge.logging import get_user_logger
-from bridge.pipelines.policies.gh2bt import reconcile_gh_over_bt
+from bridge.pipelines.policies.gh2bt import reconcile_gh_ontop_bt
 from bridge.pipelines.utils import find_matching_enum_member
 
 logger = get_user_logger()
@@ -92,12 +92,10 @@ def _cast_to_biotools_languages(languages: set[str]) -> list[LanguageEnum] | Non
 def map_language(gh_languages: Language | None, bt_languages: list[LanguageEnum] | None) -> list[LanguageEnum] | None:
     """
     Map and reconcile GitHub and bio.tools programming languages using the generic
-    GitHub-over-bio.tools policy.
+    GitHub-on-top-of-bio.tools policy.
 
     GitHub language keys and bio.tools ``LanguageEnum`` values are normalized to
-    lowercased string sets for comparison. When GitHub is authoritative, the
-    GitHub set is mapped back to ``LanguageEnum`` values; unknown languages are
-    skipped with a log entry.
+    lowercased string sets for comparison.
 
     Parameters
     ----------
@@ -116,16 +114,11 @@ def map_language(gh_languages: Language | None, bt_languages: list[LanguageEnum]
     gh_norm = _to_lang_set_gh(gh_languages)
     bt_norm = _to_lang_set_bt(bt_languages)
 
-    # if GitHub has nothing, keep existing
-    if gh_norm is None or len(gh_norm) == 0:
-        logger.unchanged("No GitHub languages found, nothing to map.")
-        return bt_languages
-
-    # use the generic reconciler on the *set* representation
-    return reconcile_gh_over_bt(
+    return reconcile_gh_ontop_bt(
         gh_norm=gh_norm,
         bt_norm=bt_norm,
         bt_value=bt_languages,
-        build_bt_from_gh=_cast_to_biotools_languages,
+        build_bt_from_gh=None,
+        build_bt_from_norm=lambda bt_norm: _cast_to_biotools_languages(bt_norm),
         log_label="languages",
     )

--- a/src/bridge/pipelines/policies/gh2bt/__init__.py
+++ b/src/bridge/pipelines/policies/gh2bt/__init__.py
@@ -2,6 +2,10 @@
 Generic reconciliation policies for GitHub to bio.tools mapping.
 """
 
+from .reconcile_gh_ontop_bt import reconcile_gh_ontop_bt
 from .reconcile_gh_over_bt import reconcile_gh_over_bt
 
-__all__ = ["reconcile_gh_over_bt"]
+__all__ = [
+    "reconcile_gh_over_bt",
+    "reconcile_gh_ontop_bt",
+]

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
@@ -1,0 +1,100 @@
+"""
+Generic reconciliation policy for GitHub-to-bio.tools *additive* mappings.
+
+This module provides a generic function to reconcile metadata between
+GitHub and bio.tools according to a defined policy that adds GitHub values
+on top of existing bio.tools values without removing any.
+"""
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from bridge.logging import get_user_logger
+
+logger = get_user_logger()
+
+
+BT = TypeVar("BT")  # bio.tools type
+GHN = TypeVar("GHN")  # element type for GitHub set (usually same as BTN)
+BTN = TypeVar("BTN")  # element type for bio.tools set
+
+
+def reconcile_gh_over_bt(
+    *,
+    gh_norm: set[GHN] | None,
+    bt_norm: set[BTN] | None,
+    bt_value: BT | None,
+    build_bt_from_gh: Callable[[GHN], set[BTN] | None],
+    build_bt_from_norm: Callable[[set[BTN]], BT],
+    log_label: str,
+) -> BT | None:
+    """
+    Apply a generic GitHub-on-top-of-bio.tools policy for additive metadata.
+
+    This function is intended for *multi-valued* fields where GitHub can
+    contribute additional values on top of existing bio.tools ones (e.g. functions).
+    Both GitHub and bio.tools values are provided as sets and the function computes
+    the subset of GitHub values that are missing from bio.tools.
+
+    Policy:
+    1. If ``gh_norm`` is ``None`` or empty,
+        GitHub is treated as silent and no change is made to bio.tools.
+        An "unchanged" log entry is emitted.
+    2. If ``gh_norm`` contains values, each value is mapped to zero or more
+        bio.tools values via ``build_bt_from_gh``.
+    3. If ``bt_norm`` is ``None`` or empty, all bio.tools values derived from GitHub are added to bio.tools.
+        An "added" log entry is emitted.
+    4. If both ``gh_norm`` and ``bt_norm`` contain values,
+        the union of the existing bio.tools values and the new values derived from GitHub is computed.
+    5. If the union is the same as the existing bio.tools values, no change is made.
+        An "exact" log entry is emitted.
+    6. If the union contains additional values compared to the existing bio.tools values,
+        the new values are added to bio.tools and an "added" log entry is emitted indicating the number of new values.
+
+    Parameters
+    ----------
+    gh_norm : set[GHN] | None
+        A set of normalized values derived from GitHub, or ``None`` if GitHub provides no usable value.
+    bt_norm : set[BTN] | None
+        A set of normalized values derived from the existing bio.tools metadata, or ``None`` if no value is recorded.
+    bt_value : BT | None
+        The existing bio.tools value corresponding to the field being reconciled, or ``None`` if no value is recorded.
+        This is preserved when GitHub is silent or when the normalized sets are equal.
+    build_bt_from_gh : Callable[[GHN], set[BTN] | None]
+        A callable that takes a normalized GitHub value and returns
+        a set of normalized bio.tools values derived from it,
+        or ``None`` if the GitHub value cannot be mapped to bio.tools.
+    build_bt_from_norm : Callable[[set[BTN]], BT]
+        A callable that takes a set of normalized bio.tools values and constructs
+        the corresponding concrete bio.tools value.
+    log_label : str
+        A short label used in log messages to identify the reconciled field (e.g., "function", "topic", etc.).
+
+    Returns
+    -------
+    BT | None
+        The reconciled bio.tools value, which may be the same as the existing value
+        if GitHub is silent or if the normalized sets are equal, or a new value with GitHub-derived additions.
+    """
+    if not gh_norm:
+        logger.unchanged(f"No GitHub {log_label} found, nothing to map.")
+        return bt_value
+
+    gh_norm_from_bt = build_bt_from_gh(gh_norm)
+
+    if not gh_norm_from_bt:
+        logger.unchanged(f"GitHub {log_label} could not be cast as bio.tools, nothing to map.")
+        return bt_value
+
+    if not bt_norm:
+        logger.added(f"{log_label} from GitHub: {gh_norm!r}")
+        return build_bt_from_norm(gh_norm_from_bt)
+
+    updated_bt_norm = bt_norm.union(gh_norm_from_bt)
+    nr_added = len(updated_bt_norm) - len(bt_norm)
+    if nr_added == 0:
+        logger.exact(f"GitHub {log_label} already present in bio.tools, nothing to add.")
+        return bt_value
+
+    logger.added(f"Added {nr_added} missing {log_label} from GitHub to bio.tools.")
+    return build_bt_from_norm(updated_bt_norm)

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
@@ -21,7 +21,7 @@ BTN = TypeVar("BTN")  # element type for bio.tools set
 
 def reconcile_gh_ontop_bt(
     *,
-    gh_norm: set[GHN] | None,
+    gh_norm: GHN | None,
     bt_norm: set[BTN] | None,
     bt_value: BT | None,
     build_bt_from_gh: Callable[[GHN], set[BTN] | None] | None,
@@ -80,7 +80,10 @@ def reconcile_gh_ontop_bt(
         logger.unchanged(f"No GitHub {log_label} found, nothing to map.")
         return bt_value
 
-    gh_norm_from_bt = gh_norm if build_bt_from_gh is None else build_bt_from_gh(gh_norm)
+    if build_bt_from_gh is None:
+        gh_norm_from_bt = gh_norm
+    else:
+        gh_norm_from_bt = build_bt_from_gh(gh_norm)
 
     if not gh_norm_from_bt:
         logger.unchanged(f"GitHub {log_label} could not be cast as bio.tools, nothing to map.")

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
@@ -24,7 +24,7 @@ def reconcile_gh_ontop_bt(
     gh_norm: set[GHN] | None,
     bt_norm: set[BTN] | None,
     bt_value: BT | None,
-    build_bt_from_gh: Callable[[GHN], set[BTN] | None],
+    build_bt_from_gh: Callable[[GHN], set[BTN] | None] | None,
     build_bt_from_norm: Callable[[set[BTN]], BT],
     log_label: str,
 ) -> BT | None:
@@ -80,7 +80,7 @@ def reconcile_gh_ontop_bt(
         logger.unchanged(f"No GitHub {log_label} found, nothing to map.")
         return bt_value
 
-    gh_norm_from_bt = build_bt_from_gh(gh_norm)
+    gh_norm_from_bt = gh_norm if build_bt_from_gh is None else build_bt_from_gh(gh_norm)
 
     if not gh_norm_from_bt:
         logger.unchanged(f"GitHub {log_label} could not be cast as bio.tools, nothing to map.")

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
@@ -19,7 +19,7 @@ GHN = TypeVar("GHN")  # element type for GitHub set (usually same as BTN)
 BTN = TypeVar("BTN")  # element type for bio.tools set
 
 
-def reconcile_gh_over_bt(
+def reconcile_gh_ontop_bt(
     *,
     gh_norm: set[GHN] | None,
     bt_norm: set[BTN] | None,

--- a/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
+++ b/src/bridge/pipelines/policies/gh2bt/reconcile_gh_ontop_bt.py
@@ -53,8 +53,8 @@ def reconcile_gh_ontop_bt(
 
     Parameters
     ----------
-    gh_norm : set[GHN] | None
-        A set of normalized values derived from GitHub, or ``None`` if GitHub provides no usable value.
+    gh_norm : GHN | None
+        Normalized values derived from GitHub, or ``None`` if GitHub provides no usable value.
     bt_norm : set[BTN] | None
         A set of normalized values derived from the existing bio.tools metadata, or ``None`` if no value is recorded.
     bt_value : BT | None

--- a/src/bridge/pipelines/shared/functions.py
+++ b/src/bridge/pipelines/shared/functions.py
@@ -1,0 +1,36 @@
+"""
+Shared functions utilities for pipelines.
+"""
+
+import re
+
+FUNCTION_PATTERN = re.compile(
+    r"""
+    <details>\s*
+    <summary>(?P<name>[^\r\n<]*)</summary>\s*
+    ```yaml[ \t]*\r?\n
+    #[ \t]*biotools-function[ \t]*\r?\n
+    (?P<yaml>.*?)
+    ^[ \t]*```[ \t]*\r?\n
+    \s*</details>
+    """,
+    re.DOTALL | re.VERBOSE | re.MULTILINE,
+)
+
+
+def find_matches(text: str | None) -> list[str]:
+    """
+    Find all function annotations in the given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to search for function annotations.
+
+    Returns
+    -------
+    list[FunctionItem]
+        A list of FunctionItems found in the text.
+    """
+    matches = list(FUNCTION_PATTERN.finditer(text or ""))
+    return matches

--- a/src/bridge/pipelines/shared/functions.py
+++ b/src/bridge/pipelines/shared/functions.py
@@ -34,3 +34,22 @@ def find_matches(text: str | None) -> list[str]:
     """
     matches = list(FUNCTION_PATTERN.finditer(text or ""))
     return matches
+
+
+def find_match_yamls(text: str | None) -> list[str]:
+    """
+    Find all function annotation YAML blocks in the given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to search for function annotations.
+
+    Returns
+    -------
+    list[str]
+        A list of YAML strings found in the function annotations in the text.
+    """
+    matches = find_matches(text)
+    yamls = [m.group("yaml") for m in matches]
+    return yamls

--- a/src/bridge/pipelines/shared/functions.py
+++ b/src/bridge/pipelines/shared/functions.py
@@ -9,7 +9,7 @@ FUNCTION_PATTERN = re.compile(
     <details>\s*
     <summary>(?P<name>[^\r\n<]*)</summary>\s*
     ```yaml[ \t]*\r?\n
-    #[ \t]*biotools-function[ \t]*\r?\n
+    \#[ \t]*biotools-function[ \t]*\r?\n
     (?P<yaml>.*?)
     ^[ \t]*```[ \t]*\r?\n
     \s*</details>
@@ -18,7 +18,7 @@ FUNCTION_PATTERN = re.compile(
 )
 
 
-def find_matches(text: str | None) -> list[str]:
+def find_matches(text: str | None) -> list[re.Match[str]]:
     """
     Find all function annotations in the given text.
 
@@ -29,8 +29,8 @@ def find_matches(text: str | None) -> list[str]:
 
     Returns
     -------
-    list[FunctionItem]
-        A list of FunctionItems found in the text.
+    list[re.Match[str]]
+        A list of regex match objects found in the text.
     """
     matches = list(FUNCTION_PATTERN.finditer(text or ""))
     return matches

--- a/src/bridge/pipelines/utils/__init__.py
+++ b/src/bridge/pipelines/utils/__init__.py
@@ -15,7 +15,7 @@ from .cleaning import (
 from .comparisons import str_contain_each_other
 from .conversions import find_matching_enum_member, object_to_primitive, svg_to_base64
 from .files import check_file_with_extension_exists, get_file_content, load_dict_from_yaml_file
-from .templating import fill_template, remove_first_snippet_from_text
+from .templating import fill_template, remove_first_snippet_from_text, separate_snippets_from_text
 
 __all__ = [
     "check_file_with_extension_exists",
@@ -36,4 +36,5 @@ __all__ = [
     "find_matching_enum_member",
     "object_to_primitive",
     "str_contain_each_other",
+    "separate_snippets_from_text",
 ]

--- a/src/bridge/pipelines/utils/templating.py
+++ b/src/bridge/pipelines/utils/templating.py
@@ -5,6 +5,47 @@ Utilities for handling string templating.
 import re
 
 
+def separate_snippet_from_text(text: str | None, snippet: str | None) -> tuple[str, str]:
+    """
+    Separate the first occurrence of a snippet from a string.
+
+    This helper searches for the first occurrence of `snippet` in `text` and
+    returns a tuple containing the content before and after that occurrence.
+    If the snippet is not found, the original text is returned as the "before"
+    part and the "after" part is an empty string.
+
+    Parameters
+    ----------
+    text : str | None
+        The original text from which the snippet should be separated. May be
+        ``None``, in which case both returned parts will be empty strings.
+    snippet : str | None
+        The snippet to separate from the text. If ``None`` or empty, no separation
+        is performed and the entire text is returned as the "before" part.
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple containing the "before" and "after" parts of the text relative to
+        the first occurrence of the snippet. If the snippet is not found, the first
+        element is the original text (or an empty string if `text` is ``None``) and
+        the second element is an empty string.
+    """
+    if not text:
+        return "", ""
+
+    if not snippet:
+        return text, ""
+
+    idx = text.find(snippet)
+    if idx == -1:
+        return text, ""
+
+    before = text[:idx]
+    after = text[idx + len(snippet) :]
+    return before, after
+
+
 def remove_first_snippet_from_text(text: str | None, snippet: str | None) -> str:
     """
     Remove the first occurrence of a snippet from a string.
@@ -35,17 +76,51 @@ def remove_first_snippet_from_text(text: str | None, snippet: str | None) -> str
         A new string with the first occurrence of `snippet` removed, or the
         original text (or an empty string) if no removal is performed.
     """
-    if not text:
-        return ""
+    before, after = separate_snippet_from_text(text, snippet)
 
-    if not snippet:
-        return text
+    return before + after
 
-    idx = text.find(snippet)
-    if idx == -1:
-        return text
 
-    return text[:idx] + text[idx + len(snippet) :]
+def separate_snippets_from_text(text: str | None, snippets: list[str]) -> tuple[str, str]:
+    """
+    Separate the first occurrence of a list of snippets from a string.
+    Then remove the remaining snippets from the "after" part.
+
+    This helper searches for the first occurrence of any snippet in `snippets`
+    within `text` and separates the text into "before" and "after" parts based
+    on that first match. It then removes all subsequent occurrences of any of the
+    snippets from the "after" part. If no snippets are found, the original text is
+    returned as the "before" part and the "after" part is an empty string.
+
+    Parameters
+    ----------
+    text : str | None
+        The original text from which the snippets should be separated. May be
+        ``None``, in which case both returned parts will be empty strings.
+    snippets : list[str]
+        A list of snippets to search for and separate from the text. If the list is
+        empty, no separation is performed and the entire text is returned as the "before" part.
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple containing the "before" and "after" parts of the text relative to
+        the first occurrence of any snippet. The "after" part has all subsequent
+        occurrences of any snippets removed. If no snippets are found, the first
+        element is the original text (or an empty string if `text` is ``None``)
+        and the second element is an empty string.
+    """
+    first_snippet = snippets[0] if snippets else None
+    before, after = separate_snippet_from_text(text, first_snippet)
+
+    if len(snippets) <= 1:
+        return before, after
+
+    remaining_snippets = snippets[1:]
+    for snippet in remaining_snippets:
+        after = remove_first_snippet_from_text(after, snippet)
+
+    return before, after
 
 
 def fill_template(template: str, placeholders: dict[str, str]) -> str:

--- a/tests/unit/pipelines/bt2gh_for_pr_issues/map_funcs/test_functions.py
+++ b/tests/unit/pipelines/bt2gh_for_pr_issues/map_funcs/test_functions.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for mapping bio.tools functions to GitHub (map_functions + map_functions_to_readme).
+
+These tests focus strictly on behavior, not logging. We patch:
+- fill_template: deterministic placeholder substitution
+- find_matches: deterministic "README contains functions?" signals + match blocks
+- separate_snippets_from_text: deterministic splitting so we can assert exact output
+- yaml.safe_dump: deterministic YAML rendering so _build_function output is stable
+
+We avoid depending on Pydantic FunctionItem by using minimal stubs that provide:
+- .operation (list of op objects with .term/.uri)
+- .model_dump(exclude_none=True)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import bridge.pipelines.bt2gh_for_pr_issues.map_funcs.functions as mod
+
+
+# -----------------------------
+# Minimal stubs
+# -----------------------------
+
+
+@dataclass
+class _Op:
+    term: str | None = None
+    uri: str | None = None
+
+
+class _Func:
+    def __init__(self, ops: list[_Op], dumped: dict):
+        self.operation = ops
+        self._dumped = dumped
+
+    def model_dump(self, exclude_none: bool = True):
+        return self._dumped
+
+
+class _Match:
+    def __init__(self, block: str):
+        self._block = block
+
+    def group(self, idx_or_name=0):
+        # module uses m.group(0) only here
+        assert idx_or_name == 0
+        return self._block
+
+
+# -----------------------------
+# Fixtures: patch dependencies
+# -----------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_helpers(monkeypatch):
+    # Deterministic template filler (handles {{K}}, {{ K}}, {{K }}, {{ K }})
+    def fake_fill_template(template: str, filling: dict[str, str]) -> str:
+        s = template
+        for k, v in filling.items():
+            for pattern in (f"{{{{ {k} }}}}", f"{{{{{k}}}}}", f"{{{{ {k}}}}}", f"{{{{{k} }}}}"):
+                s = s.replace(pattern, v)
+        return s
+
+    # Deterministic YAML dump
+    def fake_safe_dump(data, **_kwargs):
+        lines = []
+        for k, v in data.items():
+            lines.append(f"{k}: {v}")
+        return "\n".join(lines) + "\n"
+
+    monkeypatch.setattr(mod, "fill_template", fake_fill_template)
+    monkeypatch.setattr(mod.yaml, "safe_dump", fake_safe_dump)
+
+
+@pytest.fixture
+def _patch_find_matches(monkeypatch):
+    """
+    Patch find_matches; tests can replace by monkeypatching again if needed.
+    Default: no functions in README.
+    """
+    monkeypatch.setattr(mod, "find_matches", lambda _txt: [])
+
+
+@pytest.fixture
+def _patch_separate_snippets(monkeypatch):
+    """
+    Patch separate_snippets_from_text; default is a naive split:
+    remove all snippets and return (before, after) as (prefix, suffix)
+    around the first occurrence of the first snippet.
+
+    Tests that care will provide explicit behavior via monkeypatch.
+    """
+
+    def fake_sep(text: str, snippets: list[str]):
+        # simple, deterministic behavior:
+        # remove each snippet once (first occurrence), and return remaining as (before, after="")
+        out = text
+        for snip in snippets:
+            idx = out.find(snip)
+            if idx >= 0:
+                out = out[:idx] + out[idx + len(snip) :]
+        return out, ""
+
+    monkeypatch.setattr(mod, "separate_snippets_from_text", fake_sep)
+
+
+# -----------------------------
+# Helpers to build functions
+# -----------------------------
+
+
+def F(name_term: str | None, name_uri: str | None, dumped: dict) -> _Func:
+    return _Func(ops=[_Op(term=name_term, uri=name_uri)], dumped=dumped)
+
+
+# =========================================================
+# map_functions (issue creation)
+# =========================================================
+
+TITLE = "Add function annotations from bio.tools metadata"
+
+
+def _body(out: dict[str, str] | None) -> str:
+    assert out is not None
+    assert list(out.keys()) == [TITLE]
+    return out[TITLE]
+
+
+@pytest.mark.parametrize(
+    "case, matches, bt_functions, expect_issue",
+    [
+        (
+            "functions already in readme => no issue",
+            [_Match("<details>...</details>")],
+            [F("X", None, {"x": 1})],
+            False,
+        ),
+        ("bt_functions None => no issue", [], None, False),
+        ("bt_functions empty => no issue", [], [], False),
+        ("bt_functions present and no matches => issue", [], [F("X", None, {"x": 1})], True),
+    ],
+)
+def test_map_functions_issue_policy(case, matches, bt_functions, expect_issue, monkeypatch, _patch_helpers):
+    monkeypatch.setattr(mod, "find_matches", lambda _txt: matches)
+
+    out = mod.map_functions(gh_readme="README", bt_functions=bt_functions)
+
+    if not expect_issue:
+        assert out is None, case
+        return
+
+    body = _body(out)
+    assert "The bio.tools metadata contains the following function annotations" in body
+    assert "~~~markdown" in body
+    assert "# Functions" in body  # section header
+    # function block structure should be present
+    assert "<details>" in body
+    assert "```yaml" in body
+    assert "# biotools-function" in body
+    assert "</details>" in body
+
+
+def test_map_functions_builds_function_name_from_term_then_uri_then_fallback(
+    monkeypatch, _patch_helpers, _patch_find_matches
+):
+    # No matches => issue created
+    funcs = [
+        F("OpTerm", None, {"k": "v"}),
+        F(None, "http://edamontology.org/operation_0001", {"k2": "v2"}),
+        _Func(ops=[_Op(term=None, uri=None)], dumped={"k3": "v3"}),  # fallback name
+    ]
+
+    out = mod.map_functions(gh_readme="README", bt_functions=funcs)
+    body = _body(out)
+
+    assert "<summary>OpTerm</summary>" in body
+    assert "<summary>http://edamontology.org/operation_0001</summary>" in body
+    assert "<summary>Unnamed operation</summary>" in body
+
+
+def test_map_functions_uses_all_operations_in_name(monkeypatch, _patch_helpers, _patch_find_matches):
+    func = _Func(
+        ops=[_Op(term="A", uri=None), _Op(term=None, uri="U"), _Op(term=None, uri=None)],
+        dumped={"x": 1},
+    )
+
+    out = mod.map_functions(gh_readme="README", bt_functions=[func])
+    body = _body(out)
+
+    # joined by ", "
+    assert "<summary>A, U, Unnamed operation</summary>" in body
+
+
+# =========================================================
+# map_functions_to_readme (PR content update)
+# =========================================================
+
+
+@pytest.mark.parametrize(
+    "case, gh_readme, matches, bt_functions, expected",
+    [
+        ("readme None => unchanged", None, [], [F("X", None, {"x": 1})], None),
+        ("no matches => unchanged", "Intro\nBody\n", [], [F("X", None, {"x": 1})], "Intro\nBody\n"),
+        ("matches but bt_functions None => unchanged", "X", [_Match("OLD")], None, "X"),
+        ("matches but bt_functions empty => unchanged", "X", [_Match("OLD")], [], "X"),
+    ],
+)
+def test_map_functions_to_readme_no_update_cases(
+    case, gh_readme, matches, bt_functions, expected, monkeypatch, _patch_helpers
+):
+    monkeypatch.setattr(mod, "find_matches", lambda _txt: matches)
+
+    out = mod.map_functions_to_readme(gh_readme=gh_readme, bt_functions=bt_functions)
+    assert out == expected, case
+
+
+def test_map_functions_to_readme_replaces_all_existing_blocks(monkeypatch, _patch_helpers, _patch_separate_snippets):
+    gh_readme = "BEFORE\nOLD1\nMIDDLE\nOLD2\nAFTER\n"
+    blocks = ["OLD1", "OLD2"]
+    monkeypatch.setattr(mod, "find_matches", lambda _txt: [_Match(b) for b in blocks])
+
+    # Force a split that proves we removed both blocks and inserted new ones between before/after
+    def fake_sep(text: str, snippets: list[str]):
+        assert snippets == blocks
+        return ("BEFORE\n", "\nAFTER\n")
+
+    monkeypatch.setattr(mod, "separate_snippets_from_text", fake_sep)
+
+    new_funcs = [
+        F("NewOp", None, {"a": 1}),
+        F("Another", None, {"b": 2}),
+    ]
+
+    out = mod.map_functions_to_readme(gh_readme=gh_readme, bt_functions=new_funcs)
+
+    assert out is not None
+    assert out.startswith("BEFORE\n")
+    assert out.endswith("\nAFTER\n")
+
+    # Old blocks gone
+    assert "OLD1" not in out
+    assert "OLD2" not in out
+
+    # New blocks inserted
+    assert "<summary>NewOp</summary>" in out
+    assert "<summary>Another</summary>" in out
+    assert "# biotools-function" in out
+    assert "a: 1" in out  # from fake_safe_dump
+    assert "b: 2" in out
+
+
+def test_map_functions_to_readme_calls_separate_snippets_with_exact_match_blocks(monkeypatch, _patch_helpers):
+    gh_readme = "X\nOLD\nY\n"
+    m1 = _Match("OLD")
+    monkeypatch.setattr(mod, "find_matches", lambda _txt: [m1])
+
+    captured: dict[str, object] = {}
+
+    def fake_sep(text: str, snippets: list[str]):
+        captured["text"] = text
+        captured["snippets"] = list(snippets)
+        return ("X\n", "\nY\n")
+
+    monkeypatch.setattr(mod, "separate_snippets_from_text", fake_sep)
+
+    out = mod.map_functions_to_readme(gh_readme=gh_readme, bt_functions=[F("New", None, {"k": "v"})])
+
+    assert captured["text"] == gh_readme
+    assert captured["snippets"] == ["OLD"]
+    assert out is not None
+    assert "<summary>New</summary>" in out
+
+
+def test_build_function_template_replaces_yaml_placeholder_even_without_space(monkeypatch, _patch_helpers):
+    func = F("X", None, {"a": 1})
+    txt = mod._build_function(func)
+    assert "{{ FUNCTION_YAML" not in txt  # placeholder must be gone
+    assert "a: 1" in txt

--- a/tests/unit/pipelines/bt2gh_for_pr_issues/map_funcs/test_readme.py
+++ b/tests/unit/pipelines/bt2gh_for_pr_issues/map_funcs/test_readme.py
@@ -1,5 +1,10 @@
 """
 Unit tests for mapping bio.tools metadata onto a GitHub README (map_readme).
+
+These tests focus strictly on behavior, not logging, and keep regex/template
+parsing out of scope by patching helper functions.
+
+Updated to account for function-annotation injection via map_functions_to_readme.
 """
 
 from __future__ import annotations
@@ -79,16 +84,36 @@ def _patch_badge_helpers(monkeypatch):
     monkeypatch.setattr(mod, "fill_template", fake_fill_template)
     monkeypatch.setattr(mod, "remove_first_snippet_from_text", fake_remove_first_snippet)
 
-    # we also need to ensure mod.Badge points to our FakeBadge for type checks in helpers
+    # ensure mod.Badge points to our FakeBadge for type checks in helpers
     monkeypatch.setattr(mod, "Badge", FakeBadge)
 
     return FakeBadge
 
 
+@pytest.fixture(autouse=True)
+def _patch_map_functions_to_readme(monkeypatch):
+    """
+    Patch map_functions_to_readme so tests don't depend on regex parsing / function templates.
+
+    Default behavior: if bt_functions is truthy, append a deterministic marker block.
+    Also records calls so tests can assert it was invoked with expected args.
+    """
+    calls: list[tuple[str, object]] = []
+
+    def fake_map_functions_to_readme(content: str, bt_functions):
+        calls.append((content, bt_functions))
+        if bt_functions:
+            return content + "\n\n<!-- FUNCTIONS-INJECTED -->\n"
+        return content
+
+    monkeypatch.setattr(mod, "map_functions_to_readme", fake_map_functions_to_readme)
+    return calls
+
+
 @pytest.fixture
 def _patch_extract_existing_badges(monkeypatch):
     """
-    Patch _extract_existing_badges to be deterministic (so we don't need to rely on regex parsing here).
+    Patch _extract_existing_badges to be deterministic (so we don't rely on regex parsing here).
     Each test can override by re-patching if needed.
     """
 
@@ -181,8 +206,7 @@ def test_map_readme_adds_tool_type_badge_when_tooltype_list_present(_patch_extra
         None,
         [],
         "not-a-list",
-        [None],  # treated as list, but map_readme checks list and non-empty only; still allowed through,
-        # yet _build_readme sorts tt.value which would explode. So map_readme *must* convert these to None.
+        [None],  # invalid entries => tooltype is forced to None by map_readme
     ],
 )
 def test_map_readme_ignores_invalid_tooltype(tooltype_value, _patch_extract_existing_badges):
@@ -200,13 +224,12 @@ def test_map_readme_preserves_existing_badges_and_deduplicates(monkeypatch):
     Existing badge should be carried into output.
     If it duplicates a newly generated badge, it should only appear once.
     """
-    # Use the same FakeBadge class the autouse fixture installed as mod.Badge
     FakeBadge = mod.Badge
 
     existing = [
-        # this will be unique
+        # unique
         FakeBadge(alt_text="CI", image_url="badges/ci--passing.svg", link_url="https://ci.example"),
-        # duplicate of the generated bio.tools badge (same alt/img/link as our fake_compose_badge emits)
+        # duplicate of generated bio.tools badge
         FakeBadge(alt_text="bio.tools", image_url="badges/bio.tools--toolid.svg", link_url="https://bio.tools/toolid"),
     ]
 
@@ -273,3 +296,70 @@ def test_map_readme_returns_readme_md_key(_patch_extract_existing_badges):
     assert out.keys() == {"README.md"}
     assert isinstance(out["README.md"], str)
     assert out["README.md"]
+
+
+def test_map_readme_calls_map_functions_to_readme_with_stripped_content(
+    _patch_extract_existing_badges, _patch_map_functions_to_readme
+):
+    """
+    _build_readme strips title + existing badge full_match snippets before calling map_functions_to_readme.
+    We assert the 'content' argument is what's left (starting at the first real section).
+    """
+    calls = _patch_map_functions_to_readme
+
+    gh_readme = "# Title\n" "\n" "![CI](badges/ci--passing.svg)\n" "\n" "## Usage\n" "Do stuff.\n"
+
+    # Ensure stripping removes this badge line
+    FakeBadge = mod.Badge
+    existing_badges = [
+        FakeBadge(
+            alt_text="CI", image_url="badges/ci--passing.svg", link_url=None, full_match="![CI](badges/ci--passing.svg)"
+        )
+    ]
+    # Override extraction for this test
+    mod._extract_existing_badges = lambda _readme: existing_badges  # noqa: B010 (test-only patch)
+
+    out = mod.map_readme(
+        gh_readme=gh_readme,
+        bt_params={"name": "Tool", "biotoolsID": "toolid", "functions": ["fake-func"]},
+    )
+    text = _out_text(out)
+
+    assert calls, "map_functions_to_readme was not called"
+    content_arg, funcs_arg = calls[-1]
+
+    # Title removed
+    assert "# Title" not in content_arg
+    # Badge snippet removed from content
+    assert "![CI](badges/ci--passing.svg)" not in content_arg
+    # Remaining content starts at Usage
+    assert content_arg.lstrip().startswith("## Usage")
+
+    # Functions passed through
+    assert funcs_arg == ["fake-func"]
+
+    # And our fake injection marker shows up in output
+    assert "<!-- FUNCTIONS-INJECTED -->" in text
+
+
+def test_map_readme_does_not_inject_functions_when_none(_patch_extract_existing_badges, _patch_map_functions_to_readme):
+    calls = _patch_map_functions_to_readme
+
+    out = mod.map_readme(
+        gh_readme="# Title\n\n## Usage\nDo stuff.\n",
+        bt_params={"name": "Tool", "biotoolsID": "toolid", "functions": None},
+    )
+    text = _out_text(out)
+
+    # map_functions_to_readme still called, but should not inject marker for falsy bt_functions
+    assert calls, "map_functions_to_readme was not called"
+    assert "<!-- FUNCTIONS-INJECTED -->" not in text
+
+
+def test_map_readme_injects_functions_when_present(_patch_extract_existing_badges, _patch_map_functions_to_readme):
+    out = mod.map_readme(
+        gh_readme="# Title\n\n## Usage\nDo stuff.\n",
+        bt_params={"name": "Tool", "biotoolsID": "toolid", "functions": ["f1", "f2"]},
+    )
+    text = _out_text(out)
+    assert "<!-- FUNCTIONS-INJECTED -->" in text

--- a/tests/unit/pipelines/bt2gh_for_pr_issues/test_map.py
+++ b/tests/unit/pipelines/bt2gh_for_pr_issues/test_map.py
@@ -34,6 +34,7 @@ def test_mapbiotools2github_map_returns_expected_keys(monkeypatch, tmp_path):
         "homepage",
         "readme",
         "license",
+        "functions",
     }
 
 
@@ -134,6 +135,7 @@ def test_mapbiotools2github_readme_mapping(monkeypatch, tmp_path):
         "name": bt_tool.name,
         "biotoolsID": bt_tool.biotoolsID.root,
         "toolType": bt_tool.toolType,
+        "functions": bt_tool.function,
     }
     assert deep_unwrap(item.repo_entry) == gh_repo.readme
     assert item.method == Method.FUZZY
@@ -155,6 +157,23 @@ def test_mapbiotools2github_license_mapping(monkeypatch, tmp_path):
     assert deep_unwrap(item.repo_entry) == gh_repo.repo.license
     assert item.method == Method.FUZZY
     assert item.fn is not None  # map_license
+
+
+def test_mapbiotools2github_functions_mapping(monkeypatch, tmp_path):
+    monkeypatch.setattr(bt2gh_map_mod, "load_dict_from_yaml_file", lambda _path: {})
+
+    gh_repo = DummyGitHubRepoModel()
+    bt_tool = DummyBioToolsTool()
+    mapper = MapBioTools2GitHub(repo=gh_repo, metadata=bt_tool, repo_path=str(tmp_path))
+
+    item = mapper.map["functions"]
+    assert isinstance(item, MapItem)
+
+    # schema_entry is a list of FunctionItem in the real schema
+    assert deep_unwrap(item.schema_entry) == bt_tool.function
+    assert deep_unwrap(item.repo_entry) == gh_repo.readme
+    assert item.method == Method.FUZZY
+    assert item.fn is not None  # map_functions
 
 
 def test_mapbiotools2github_citation_mapping_loads_from_yaml(monkeypatch, tmp_path):

--- a/tests/unit/pipelines/dummy/dummy_biotools.py
+++ b/tests/unit/pipelines/dummy/dummy_biotools.py
@@ -5,6 +5,7 @@ from bridge.core.biotools import (
     License as BioToolsLicense,
     TopicItem,
     FunctionItem,
+    OperationItem,
     ToolTypeEnum,
     LanguageEnum,
     LinkItem,
@@ -42,8 +43,15 @@ class DummyBioToolsTool:
         # topic is a list of TopicItem (needed by topics mapping)
         self.topic = [TopicItem(term="Genomics", uri="http://edamontology.org/topic_0622")]
 
-        # function is a list[FunctionItem] or None. If your mapper uses it, include a minimal stub.
-        # If not used, leaving None is fine.
+        # function is a list[FunctionItem] or None.
+        # self.function = [
+        #     FunctionItem(
+        #         operation=OperationItem(
+        #             term="Multiple sequence alignment",
+        #             uri="http://edamontology.org/operation_0492",
+        #         ),
+        #     )
+        # ]
         self.function = None
 
         # fields used by other pipelines

--- a/tests/unit/pipelines/dummy/dummy_biotools.py
+++ b/tests/unit/pipelines/dummy/dummy_biotools.py
@@ -44,15 +44,16 @@ class DummyBioToolsTool:
         self.topic = [TopicItem(term="Genomics", uri="http://edamontology.org/topic_0622")]
 
         # function is a list[FunctionItem] or None.
-        # self.function = [
-        #     FunctionItem(
-        #         operation=OperationItem(
-        #             term="Multiple sequence alignment",
-        #             uri="http://edamontology.org/operation_0492",
-        #         ),
-        #     )
-        # ]
-        self.function = None
+        self.function = [
+            FunctionItem(
+                operation=[
+                    OperationItem(
+                        term="Multiple sequence alignment",
+                        uri="http://edamontology.org/operation_0492",
+                    )
+                ],
+            )
+        ]
 
         # fields used by other pipelines
         self.documentation = None

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_biotools_id.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_biotools_id.py
@@ -12,6 +12,7 @@ import pytest
 import httpx
 
 import bridge.pipelines.gh2bt_for_meta.map_funcs.biotools_id as mod
+from bridge.core.biotools import BiotoolsIdType
 
 pytestmark = pytest.mark.asyncio
 
@@ -29,13 +30,13 @@ def _http_500():
 
 
 @pytest.mark.parametrize(
-    "gh_name, bt_id, expected",
+    "gh_name, bt_id, expected_root",
     [
         (None, None, None),
-        (None, "existing-id", "existing-id"),
+        (None, BiotoolsIdType("existing-id"), "existing-id"),
     ],
 )
-async def test_map_biotools_id_no_github_name_preserves_bt_id(monkeypatch, gh_name, bt_id, expected):
+async def test_map_biotools_id_no_github_name_preserves_bt_id(monkeypatch, gh_name, bt_id, expected_root):
     # Should not call out at all when gh_name is None
     calls = []
 
@@ -46,7 +47,13 @@ async def test_map_biotools_id_no_github_name_preserves_bt_id(monkeypatch, gh_na
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
     out = await mod.map_biotools_id(gh_name=gh_name, bt_id=bt_id)
-    assert out == expected
+
+    if expected_root is None:
+        assert out is None
+    else:
+        assert out is not None
+        assert out.root == expected_root
+
     assert calls == []
 
 
@@ -60,8 +67,10 @@ async def test_map_biotools_id_preserves_bt_id_when_names_contain_each_other(mon
 
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
-    out = await mod.map_biotools_id(gh_name="MyRepo", bt_id="myrepo")
-    assert out == "myrepo"
+    bt_id = BiotoolsIdType("myrepo")
+    out = await mod.map_biotools_id(gh_name="MyRepo", bt_id=bt_id)
+
+    assert out == bt_id
     assert calls == []
 
 
@@ -72,8 +81,10 @@ async def test_map_biotools_id_uses_github_name_if_free(monkeypatch):
 
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
-    out = await mod.map_biotools_id(gh_name="  RepoName  ", bt_id="different")
-    assert out == "RepoName"
+    out = await mod.map_biotools_id(gh_name="  RepoName  ", bt_id=BiotoolsIdType("different"))
+
+    assert out is not None
+    assert out.root == "RepoName"
 
 
 async def test_map_biotools_id_generates_suffix_when_github_name_taken(monkeypatch):
@@ -89,8 +100,10 @@ async def test_map_biotools_id_generates_suffix_when_github_name_taken(monkeypat
 
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
-    out = await mod.map_biotools_id(gh_name="Repo", bt_id="something-else")
-    assert out == "Repo-3"
+    out = await mod.map_biotools_id(gh_name="Repo", bt_id=BiotoolsIdType("something-else"))
+
+    assert out is not None
+    assert out.root == "Repo-3"
 
 
 async def test_map_biotools_id_returns_none_when_no_suffix_available(monkeypatch):
@@ -101,7 +114,7 @@ async def test_map_biotools_id_returns_none_when_no_suffix_available(monkeypatch
 
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
-    out = await mod.map_biotools_id(gh_name="Repo", bt_id="old")
+    out = await mod.map_biotools_id(gh_name="Repo", bt_id=BiotoolsIdType("old"))
     assert out is None
 
 
@@ -112,4 +125,6 @@ async def test_map_biotools_id_bt_id_none_still_uses_github_name_if_free(monkeyp
     monkeypatch.setattr(mod, "compose_biotools_metadata", _compose)
 
     out = await mod.map_biotools_id(gh_name="Repo", bt_id=None)
-    assert out == "Repo"
+
+    assert out is not None
+    assert out.root == "Repo"

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_functions.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_functions.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for mapping GitHub function annotations to bio.tools functions (gh2bt map_functions).
+
+These tests focus on behavior, not logging. We patch:
+- find_match_yamls: deterministic extraction from README
+- yaml.safe_load: real (safe) parsing of YAML strings
+- object_to_primitive / normalize_dict_strings: simplified + deterministic (so packing is stable)
+- reconcile_gh_ontop_bt: real (we test integration-ish behavior), but we also
+  include one test that patches it to assert the normalized inputs if you want.
+
+We use minimal FunctionItem-like stubs via monkeypatching the module's FunctionItem
+constructor to avoid depending on Pydantic validation details in unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import bridge.pipelines.gh2bt_for_meta.map_funcs.functions as mod
+
+
+# -----------------------------
+# Minimal FunctionItem stub
+# -----------------------------
+
+
+@dataclass(frozen=True)
+class _FuncItem:
+    """
+    A minimal stand-in for bridge.core.biotools.FunctionItem.
+
+    We store the raw dict payload and expose it in a way the mapping code expects:
+    - It must be constructible as FunctionItem(**data)
+    - object_to_primitive(FunctionItem) must produce a dict
+    """
+
+    payload: dict[str, Any]
+
+
+# -----------------------------
+# Helpers
+# -----------------------------
+
+
+def _fi(**payload: Any) -> _FuncItem:
+    return _FuncItem(payload=payload)
+
+
+def _yaml_for(payload: dict[str, Any]) -> str:
+    """
+    Produce a simple YAML string. We keep it small and explicit.
+    """
+    # Minimal YAML: key: value, and lists as "-".
+    # For these tests, safe_load handles it.
+    import yaml as _yaml  # local import to avoid confusion with mod.yaml
+
+    return _yaml.safe_dump(payload, sort_keys=False)
+
+
+# -----------------------------
+# Fixtures: patch internals for determinism
+# -----------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_functionitem_and_primitives(monkeypatch):
+    # Patch FunctionItem in the module under test to our stub constructor.
+    monkeypatch.setattr(mod, "FunctionItem", lambda **data: _FuncItem(payload=dict(data)))
+
+    # object_to_primitive: unwrap our stub; pass dicts through
+    def fake_object_to_primitive(x):
+        if isinstance(x, _FuncItem):
+            return dict(x.payload)
+        if isinstance(x, dict):
+            return dict(x)
+        return x
+
+    # normalize_dict_strings: no-op except ensure strings are stripped
+    def fake_normalize_dict_strings(d):
+        def norm(v):
+            if isinstance(v, str):
+                return v.strip()
+            if isinstance(v, list):
+                return [norm(i) for i in v]
+            if isinstance(v, dict):
+                return {k: norm(val) for k, val in v.items()}
+            return v
+
+        return norm(dict(d))
+
+    monkeypatch.setattr(mod, "object_to_primitive", fake_object_to_primitive)
+    monkeypatch.setattr(mod, "normalize_dict_strings", fake_normalize_dict_strings)
+
+
+@pytest.fixture
+def _patch_find_match_yamls(monkeypatch):
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [])
+
+
+# =========================================================
+# Unit tests for helpers: packing/canonicalization
+# =========================================================
+
+
+def test_pack_ignores_note_and_cmd_when_requested():
+    fi = _fi(
+        operation=[{"term": "X"}],
+        note="hello",
+        cmd="--flag",
+    )
+    a = mod._pack_function_item(fi, ignore_free_text=False)
+    b = mod._pack_function_item(fi, ignore_free_text=True)
+    assert a != b
+    # removing note/cmd should remove those substrings from packed JSON
+    assert "note" in a
+    assert "cmd" in a
+    assert "note" not in b
+    assert "cmd" not in b
+
+
+def test_pack_canonicalizes_operation_list_order():
+    fi1 = _fi(operation=[{"term": "A"}, {"term": "B"}])
+    fi2 = _fi(operation=[{"term": "B"}, {"term": "A"}])
+    assert mod._pack_function_item(fi1) == mod._pack_function_item(fi2)
+
+
+def test_pack_canonicalizes_input_format_order_and_input_list_order():
+    fi1 = _fi(
+        operation=[{"term": "X"}],
+        input=[
+            {"data": {"term": "Seq"}, "format": [{"term": "FASTA"}, {"term": "TXT"}]},
+            {"data": {"term": "Align"}, "format": [{"term": "SAM"}]},
+        ],
+    )
+    fi2 = _fi(
+        operation=[{"term": "X"}],
+        input=[
+            {"data": {"term": "Align"}, "format": [{"term": "SAM"}]},
+            {"data": {"term": "Seq"}, "format": [{"term": "TXT"}, {"term": "FASTA"}]},  # swapped
+        ],
+    )
+    assert mod._pack_function_item(fi1) == mod._pack_function_item(fi2)
+
+
+def test_unpack_roundtrip_matches_packed_semantics():
+    fi = _fi(operation=[{"term": "X"}], output=[{"data": {"term": "Y"}}])
+    packed = mod._pack_function_item(fi)
+    unpacked = mod._unpack_function_item(packed)
+    assert isinstance(unpacked, _FuncItem)
+    assert mod._pack_function_item(unpacked) == packed
+
+
+# =========================================================
+# _extract_functions_from_readme behavior
+# =========================================================
+
+
+@pytest.mark.parametrize(
+    "case, yamls, expected_count",
+    [
+        ("no yamls => None", [], 0),
+        ("one valid yaml => one function", [_yaml_for({"operation": [{"term": "X"}]})], 1),
+        (
+            "two valid yamls => two functions",
+            [
+                _yaml_for({"operation": [{"term": "X"}]}),
+                _yaml_for({"operation": [{"term": "Y"}]}),
+            ],
+            2,
+        ),
+    ],
+)
+def test_extract_functions_from_readme_counts_valid_blocks(case, yamls, expected_count, monkeypatch):
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: list(yamls))
+
+    keys = mod._extract_functions_from_readme("README")
+    if expected_count == 0:
+        assert keys is None, case
+    else:
+        assert isinstance(keys, set)
+        assert len(keys) == expected_count
+
+
+def test_extract_functions_from_readme_skips_non_dict_yaml(monkeypatch):
+    # YAML that loads to a list => skipped => None
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: ["- a\n- b\n"])
+    keys = mod._extract_functions_from_readme("README")
+    assert keys is None
+
+
+def test_extract_functions_from_readme_skips_yaml_parse_errors(monkeypatch):
+    # invalid YAML => safe_load raises YAMLError => skipped => None
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [": bad ::: yaml"])
+    keys = mod._extract_functions_from_readme("README")
+    assert keys is None
+
+
+def test_extract_functions_from_readme_dedupes_semantically_equivalent_blocks(monkeypatch):
+    # same function but with operation list in different order => same packed key => set size 1
+    y1 = _yaml_for({"operation": [{"term": "A"}, {"term": "B"}]})
+    y2 = _yaml_for({"operation": [{"term": "B"}, {"term": "A"}]})
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [y1, y2])
+
+    keys = mod._extract_functions_from_readme("README")
+    assert keys is not None
+    assert len(keys) == 1
+
+
+# =========================================================
+# map_functions reconciliation behavior (via reconcile_gh_ontop_bt)
+# =========================================================
+
+
+def test_map_functions_github_silent_preserves_bt(monkeypatch, _patch_find_match_yamls):
+    # gh_readme is None => reconcile_gh_ontop_bt returns bt_value unchanged
+    bt = [_fi(operation=[{"term": "BT"}])]
+    out = mod.map_functions(gh_readme=None, bt_functions=bt)
+    assert out == bt
+
+
+def test_map_functions_when_bt_missing_builds_from_github(monkeypatch):
+    # GitHub has functions => bt_norm None => returns built list
+    y = _yaml_for({"operation": [{"term": "GH"}]})
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [y])
+
+    out = mod.map_functions(gh_readme="README", bt_functions=None)
+    assert out is not None
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert out[0].payload["operation"][0]["term"] == "GH"
+
+
+def test_map_functions_exact_match_preserves_original_bt_object(monkeypatch):
+    # Same function present in bt and GitHub => union adds nothing => returns bt_value (same list object)
+    payload = {"operation": [{"term": "Same"}]}
+    y = _yaml_for(payload)
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [y])
+
+    bt = [_fi(**payload)]
+    out = mod.map_functions(gh_readme="README", bt_functions=bt)
+    assert out is bt  # preserved (exact)
+
+
+def test_map_functions_conflict_adds_github_on_top_of_bt(monkeypatch):
+    # bt has A, GH has B => result has A and B (order not guaranteed)
+    y = _yaml_for({"operation": [{"term": "B"}]})
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [y])
+
+    bt = [_fi(operation=[{"term": "A"}])]
+    out = mod.map_functions(gh_readme="README", bt_functions=bt)
+
+    assert out is not None
+    terms = {item.payload["operation"][0]["term"] for item in out}
+    assert terms == {"A", "B"}
+
+
+def test_map_functions_github_functions_all_invalid_preserves_bt(monkeypatch):
+    # GitHub YAML is non-dict => _extract_functions_from_readme returns None => treated as "cannot build" => preserve bt
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: ["- not-a-dict\n- still-not\n"])
+
+    bt = [_fi(operation=[{"term": "A"}])]
+    out = mod.map_functions(gh_readme="README", bt_functions=bt)
+    assert out == bt
+
+
+def test_map_functions_strips_strings_before_packing_so_equivalent_whitespace_matches(monkeypatch):
+    # bt has "X", GH has " X " => normalize_dict_strings strips => packed keys match => preserve bt
+    y = _yaml_for({"operation": [{"term": "  X  "}]})
+    monkeypatch.setattr(mod, "find_match_yamls", lambda _readme: [y])
+
+    bt = [_fi(operation=[{"term": "X"}])]
+    out = mod.map_functions(gh_readme="README", bt_functions=bt)
+
+    assert out is bt

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_language.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_language.py
@@ -38,8 +38,8 @@ def _gh_langs(d: dict[str, int] | None) -> Language | None:
             [LanguageEnum.JavaScript, LanguageEnum.Python],
             [LanguageEnum.JavaScript, LanguageEnum.Python],
         ),
-        # --- Conflict: GitHub wins (bio.tools overwritten) ---
-        (_gh_langs({"Python": 10}), [LanguageEnum.R], [LanguageEnum.Python]),
+        # --- Conflict: GitHub adds to bio.tools ---
+        (_gh_langs({"Python": 10}), [LanguageEnum.R], [LanguageEnum.Python, LanguageEnum.R]),
         (
             _gh_langs({"Python": 10, "JavaScript": 5}),
             [LanguageEnum.Python],

--- a/tests/unit/pipelines/gh2bt_for_meta/test_main.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/test_main.py
@@ -78,6 +78,7 @@ async def test_run_passes_repo_and_existing_metadata_into_mapper_and_builds_mode
         "version": _Runner([VersionType(root="2.0.0")]),
         "documentation": _Runner(existing.documentation),
         "publication": _Runner(existing.publication),
+        "functions": _Runner(existing.function),
     }
     patch_mapper["map"] = runners
 
@@ -116,6 +117,7 @@ async def test_run_sets_placeholder_description_when_mapper_returns_none(patch_m
         "version": _Runner([VersionType(root="1.2.3")]),
         "documentation": _Runner(None),
         "publication": _Runner(None),
+        "functions": _Runner(None),
     }
     patch_mapper["map"] = runners
 
@@ -146,6 +148,7 @@ async def test_run_works_when_existing_metadata_is_none(patch_mapper):
         "version": _Runner([VersionType(root="1.2.3")]),
         "documentation": _Runner(None),
         "publication": _Runner(None),
+        "functions": _Runner(None),
     }
     patch_mapper["map"] = runners
 

--- a/tests/unit/pipelines/gh2bt_for_meta/test_map.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/test_map.py
@@ -37,6 +37,7 @@ def test_mapgithub2biotools_map_returns_expected_keys(monkeypatch, tmp_path):
         "maturity",
         "version",
         "publication",
+        "functions",
     }
 
 
@@ -199,6 +200,21 @@ def test_mapgithub2biotools_version_mapping(monkeypatch, tmp_path):
     assert deep_unwrap(item.repo_entry) == gh_repo.latest_release.tag_name
     assert item.method == Method.EXACT
     assert item.fn is not None  # map_version
+
+
+def test_mapgithub2biotools_functions_mapping(monkeypatch, tmp_path):
+    monkeypatch.setattr(gh2bt_map_mod, "load_dict_from_yaml_file", lambda _path: {})
+
+    gh_repo = DummyGitHubRepoModel()
+    bt_tool = DummyBioToolsTool()
+    mapper = MapGitHub2BioTools(repo=gh_repo, metadata=bt_tool, repo_path=str(tmp_path))
+
+    item = mapper.map["functions"]
+    assert isinstance(item, MapItem)
+    assert deep_unwrap(item.schema_entry) == bt_tool.function
+    assert deep_unwrap(item.repo_entry) == gh_repo.readme
+    assert item.method == Method.FUZZY
+    assert item.fn is not None  # map_functions
 
 
 def test_mapgithub2biotools_publication_mapping_from_yaml(monkeypatch, tmp_path):

--- a/tests/unit/pipelines/policies/gh2bt/test_reconcile_gh_ontop_bt.py
+++ b/tests/unit/pipelines/policies/gh2bt/test_reconcile_gh_ontop_bt.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for reconcile_gh_ontop_bt.
+
+These tests focus strictly on reconciliation behavior, not logging.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import bridge.pipelines.policies.gh2bt as recon
+
+
+def _make_build_bt_from_norm():
+    """
+    build_bt_from_norm that makes a deterministic, comparable concrete BT value.
+    We represent the concrete bio.tools value as a sorted tuple, so set ordering
+    doesn't matter in assertions.
+    """
+
+    def build_bt_from_norm(bt_norm: set[str]):
+        return tuple(sorted(bt_norm))
+
+    return build_bt_from_norm
+
+
+def _make_recording_build_bt_from_gh(return_value_factory):
+    """
+    Build a build_bt_from_gh callable that records its single argument into `calls`.
+    Returns (build_bt_from_gh, calls).
+    """
+    calls: list[object] = []
+
+    def build_bt_from_gh(x):
+        calls.append(x)
+        return return_value_factory(x)
+
+    return build_bt_from_gh, calls
+
+
+@pytest.mark.parametrize(
+    "case, gh_norm, bt_norm, bt_value, build_bt_from_gh, expected, expected_calls",
+    [
+        # -------------------------
+        # 1) GitHub silent => preserve bt_value, never calls build_bt_from_gh
+        # -------------------------
+        ("gh None => preserve", None, {"a"}, ("existing",), lambda x: {"x"}, ("existing",), []),
+        ("gh empty set => preserve", set(), {"a"}, ("existing",), lambda x: {"x"}, ("existing",), []),
+        ("gh empty list => preserve", [], {"a"}, ("existing",), lambda x: {"x"}, ("existing",), []),
+        # -------------------------
+        # 2) build_bt_from_gh is None => treat gh_norm as already-bt-norm
+        # -------------------------
+        ("build_bt_from_gh None + bt missing => build from gh", {"a", "b"}, None, None, None, ("a", "b"), []),
+        ("build_bt_from_gh None + bt empty => build from gh", {"a"}, set(), None, None, ("a",), []),
+        (
+            "build_bt_from_gh None + bt present => union and build",
+            {"b", "c"},
+            {"a", "b"},
+            ("keep-me",),
+            None,
+            ("a", "b", "c"),
+            [],
+        ),
+        # -------------------------
+        # 3) build_bt_from_gh returns None/empty => preserve bt_value
+        # -------------------------
+        ("cannot map gh => preserve (None)", {"x"}, {"a"}, ("existing",), lambda _x: None, ("existing",), [{"x"}]),
+        (
+            "cannot map gh => preserve (empty set)",
+            {"x"},
+            {"a"},
+            ("existing",),
+            lambda _x: set(),
+            ("existing",),
+            [{"x"}],
+        ),
+        # -------------------------
+        # 4) bt missing/empty => add ALL gh-derived values (build_bt_from_norm called on gh-derived)
+        # -------------------------
+        ("bt None => build from gh-derived", {"x"}, None, None, lambda _x: {"a", "b"}, ("a", "b"), [{"x"}]),
+        ("bt empty => build from gh-derived", {"x"}, set(), None, lambda _x: {"a"}, ("a",), [{"x"}]),
+        # -------------------------
+        # 5) bt present + gh-derived subset => exact => preserve bt_value
+        # -------------------------
+        (
+            "gh-derived already present => preserve",
+            {"x"},
+            {"a", "b"},
+            ("preserve-this",),
+            lambda _x: {"a"},
+            ("preserve-this",),
+            [{"x"}],
+        ),
+        (
+            "gh-derived equals bt_norm => preserve",
+            {"x"},
+            {"a"},
+            ("preserve-this",),
+            lambda _x: {"a"},
+            ("preserve-this",),
+            [{"x"}],
+        ),
+        # -------------------------
+        # 6) bt present + gh-derived adds new values => build union
+        # -------------------------
+        (
+            "gh-derived adds new => build union",
+            {"x"},
+            {"a"},
+            ("old-bt",),
+            lambda _x: {"a", "b", "c"},
+            ("a", "b", "c"),
+            [{"x"}],
+        ),
+        ("gh-derived disjoint => build union", {"x"}, {"a"}, ("old-bt",), lambda _x: {"b"}, ("a", "b"), [{"x"}]),
+    ],
+)
+def test_reconcile_gh_ontop_bt(case, gh_norm, bt_norm, bt_value, build_bt_from_gh, expected, expected_calls):
+    build_bt_from_norm = _make_build_bt_from_norm()
+
+    # Wrap build_bt_from_gh so we can assert call behavior in-table (or keep None).
+    calls: list[object] = []
+    if build_bt_from_gh is None:
+        recording_build_bt_from_gh = None
+    else:
+
+        def recording_build_bt_from_gh(x):
+            calls.append(x)
+            return build_bt_from_gh(x)
+
+    out = recon.reconcile_gh_ontop_bt(
+        gh_norm=gh_norm,
+        bt_norm=bt_norm,
+        bt_value=bt_value,
+        build_bt_from_gh=recording_build_bt_from_gh,
+        build_bt_from_norm=build_bt_from_norm,
+        log_label="field",
+    )
+
+    assert out == expected, case
+    assert calls == expected_calls, case
+
+
+def test_reconcile_gh_ontop_bt_build_bt_from_norm_called_with_exact_union_set():
+    """
+    Stronger check: ensure build_bt_from_norm receives exactly bt_norm ∪ gh_from_bt,
+    and that gh_from_bt itself (or bt_norm) isn't accidentally mutated.
+    """
+    bt_norm = {"a", "b"}
+    gh_norm = {"whatever"}
+
+    # gh maps to {"b", "c"} => union should be {"a", "b", "c"}
+    build_bt_from_gh, gh_calls = _make_recording_build_bt_from_gh(lambda _x: {"b", "c"})
+
+    captured_norms: list[set[str]] = []
+
+    def build_bt_from_norm(norm: set[str]):
+        captured_norms.append(set(norm))  # copy to ensure later mutations won't affect us
+        return tuple(sorted(norm))
+
+    out = recon.reconcile_gh_ontop_bt(
+        gh_norm=set(gh_norm),
+        bt_norm=set(bt_norm),
+        bt_value=("preserve?",),
+        build_bt_from_gh=build_bt_from_gh,
+        build_bt_from_norm=build_bt_from_norm,
+        log_label="field",
+    )
+
+    assert out == ("a", "b", "c")
+    assert gh_calls == [set(gh_norm)]
+    assert captured_norms == [{"a", "b", "c"}]
+
+
+def test_reconcile_gh_ontop_bt_when_no_additions_does_not_call_build_bt_from_norm():
+    """
+    If gh-derived values are already present (nr_added == 0), function should
+    return bt_value and MUST NOT call build_bt_from_norm.
+    """
+    bt_norm = {"a", "b"}
+    bt_value = ("keep",)
+
+    def build_bt_from_gh(_x):
+        return {"a"}  # subset => no additions
+
+    build_bt_from_norm_calls: list[set[str]] = []
+
+    def build_bt_from_norm(norm: set[str]):
+        build_bt_from_norm_calls.append(set(norm))
+        return tuple(sorted(norm))
+
+    out = recon.reconcile_gh_ontop_bt(
+        gh_norm={"x"},
+        bt_norm=set(bt_norm),
+        bt_value=bt_value,
+        build_bt_from_gh=build_bt_from_gh,
+        build_bt_from_norm=build_bt_from_norm,
+        log_label="field",
+    )
+
+    assert out == bt_value
+    assert build_bt_from_norm_calls == []

--- a/tests/unit/pipelines/shared/test_functions.py
+++ b/tests/unit/pipelines/shared/test_functions.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for shared functions utilities for pipelines.
+
+Behavior under test:
+- A function block is ONLY recognized if the code fence is ```yaml and it contains
+  a '# biotools-function' marker line.
+- The marker line is part of the fenced YAML code, but is NOT included in the
+  captured group('yaml'); group('yaml') contains only the YAML body after the marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import bridge.pipelines.shared.functions as fnmod
+
+
+def _block(
+    name: str,
+    yaml_body: str,
+    newline: str = "\n",
+    include_marker: bool = True,
+    fence_lang: str = "yaml",
+) -> str:
+    marker = f"# biotools-function{newline}" if include_marker else ""
+    return (
+        f"<details>{newline}"
+        f"<summary>{name}</summary>{newline}"
+        f"```{fence_lang}{newline}"
+        f"{marker}"
+        f"{yaml_body}{newline}"
+        f"```{newline}"
+        f"</details>"
+    )
+
+
+def test_find_matches_none_or_empty_returns_empty():
+    assert fnmod.find_matches(None) == []
+    assert fnmod.find_matches("") == []
+
+
+def test_find_match_yamls_none_or_empty_returns_empty():
+    assert fnmod.find_match_yamls(None) == []
+    assert fnmod.find_match_yamls("") == []
+
+
+def test_find_matches_single_block_captures_name_and_yaml_body_only_and_marker_is_in_code():
+    body = "operation:\n  - term: Multiple sequence alignment\n"
+    text = "Intro\n\n" + _block("Align sequences", body) + "\n\nOutro"
+
+    matches = fnmod.find_matches(text)
+    assert len(matches) == 1
+
+    m = matches[0]
+    assert m.group("name") == "Align sequences"
+
+    # group('yaml') is the body ONLY (marker excluded by design)
+    assert m.group("yaml") == body + "\n"
+
+    # but the marker is inside the overall matched code block
+    assert "# biotools-function" in m.group(0)
+
+
+def test_find_match_yamls_single_block_returns_yaml_body_only():
+    body = "output:\n  - data:\n      term: Alignment\n"
+    text = _block("Something", body)
+
+    out = fnmod.find_match_yamls(text)
+    assert out == [body + "\n"]
+
+
+def test_find_matches_multiple_blocks_returns_all_in_order_and_marker_present_in_each_match():
+    body1 = "a: 1\n"
+    body2 = "b:\n  - 2\n"
+    text = "Header\n" + _block("First", body1) + "\n\nMiddle\n\n" + _block("Second", body2) + "\nFooter\n"
+
+    matches = fnmod.find_matches(text)
+    assert [m.group("name") for m in matches] == ["First", "Second"]
+
+    # body only
+    assert [m.group("yaml") for m in matches] == [body1 + "\n", body2 + "\n"]
+
+    # marker in matched block text for each
+    assert all("# biotools-function" in m.group(0) for m in matches)
+
+    assert fnmod.find_match_yamls(text) == [body1 + "\n", body2 + "\n"]
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_find_matches_supports_windows_newlines(newline: str):
+    # Body uses \n; outer newlines vary. This should still match.
+    body = "x: 1\ny: 2\n"
+    text = _block("WinNewlines", body.rstrip("\n"), newline=newline)
+
+    matches = fnmod.find_matches(text)
+    assert len(matches) == 1
+
+    m = matches[0]
+    assert m.group("name") == "WinNewlines"
+
+    # body only
+    assert "x: 1" in m.group("yaml")
+    assert "y: 2" in m.group("yaml")
+
+    # marker present in full match
+    assert "# biotools-function" in m.group(0)
+
+
+def test_find_matches_requires_marker_comment_line():
+    text = _block("No marker", "operation:\n  - term: X\n", include_marker=False)
+    assert fnmod.find_matches(text) == []
+    assert fnmod.find_match_yamls(text) == []
+
+
+def test_find_matches_does_not_match_wrong_fence_language():
+    text = _block("Wrong fence", "a: 1\n", fence_lang="yml")
+    assert fnmod.find_matches(text) == []
+    assert fnmod.find_match_yamls(text) == []
+
+
+def test_find_matches_allows_whitespace_after_yaml_fence_and_marker_indent_and_captures_body_only():
+    text = (
+        "<details>\n"
+        "<summary>Whitespace ok</summary>\n"
+        "```yaml   \n"
+        "#    biotools-function   \n"
+        "a: 1\n"
+        "```\n"
+        "</details>\n"
+    )
+    matches = fnmod.find_matches(text)
+    assert len(matches) == 1
+
+    m = matches[0]
+    assert m.group("name") == "Whitespace ok"
+
+    # marker not in group('yaml')
+    assert m.group("yaml") == "a: 1\n"
+
+    # but marker exists in the matched code
+    assert "biotools-function" in m.group(0)
+
+
+def test_find_matches_summary_with_angle_bracket_does_not_match():
+    # '<' inside summary text prevents matching entirely due to [^\\r\\n<]*
+    text = _block("Name with <tag>", "a: 1\n")
+    assert fnmod.find_matches(text) == []
+    assert fnmod.find_match_yamls(text) == []
+
+
+def test_find_matches_yaml_is_non_greedy_stops_at_first_closing_fence():
+    body = "a: 1\n"
+    text = _block("First", body) + "\n\n" + "<details>\n<summary>Not a function</summary>\nnope\n</details>\n"
+
+    matches = fnmod.find_matches(text)
+    assert len(matches) == 1
+
+    m = matches[0]
+    assert m.group("name") == "First"
+    assert m.group("yaml") == body + "\n"
+    assert "# biotools-function" in m.group(0)


### PR DESCRIPTION
## Summary
- Made a bidirectional mapping of functions: bt function to readme and back. In bt->gh: if readme doesn't have info about functions, we suggest adding it in an issue. if readme already has function info, no issue is created and the functions update is included in the PR.
- Made a new policy for using gh on top of bt (not just replacing). Used it for the functions, and rewrote lang gh->bt mapping with it.
- Small bug fixes

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [x] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [x] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #22 