### PR TITLE
Include original data in new bio.tools JSON

### DIFF
--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -73,6 +73,10 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
         function=await mapper.map["functions"].run(),
     )
 
+    if args.existing_metadata is not None:
+        # use existing metdata and update fields that are not None in the new metadata
+        biotools_metadata = args.existing_metadata.model_copy(update=biotools_metadata.model_dump(exclude_none=True))
+
     biotools_url = settings.biotools_url
     logger.info(args.existing_metadata)
     logger.info(f"Extracted bio.tools metadata for repo {github_repo.repo.name}")

--- a/src/bridge/pipelines/gh2bt_for_meta/main.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/main.py
@@ -75,7 +75,10 @@ async def run(args: GitHubToBiotoolsForMetaPipelineArgs) -> BiotoolsToolModel:
 
     if args.existing_metadata is not None:
         # use existing metdata and update fields that are not None in the new metadata
-        biotools_metadata = args.existing_metadata.model_copy(update=biotools_metadata.model_dump(exclude_none=True))
+        base = args.existing_metadata.model_dump(exclude_none=False)
+        patch = biotools_metadata.model_dump(exclude_none=True)
+        combined = {**base, **patch}
+        biotools_metadata = BiotoolsToolModel.model_validate(combined)
 
     biotools_url = settings.biotools_url
     logger.info(args.existing_metadata)

--- a/tests/unit/pipelines/dummy/dummy_biotools.py
+++ b/tests/unit/pipelines/dummy/dummy_biotools.py
@@ -13,55 +13,48 @@ from bridge.core.biotools import (
 )
 
 
-class DummyBioToolsTool:
-    """
-    Minimal dummy for a bio.tools ToolModel-like object,
-    shaped like the real generated Pydantic models.
-    """
+from pydantic import BaseModel
+
+
+class DummyBioToolsTool(BaseModel):
+    biotoolsID: BiotoolsIdType
+    homepage: UrlftpType
+    name: str
+    description: str
+    license: BioToolsLicense
+    version: list[VersionType]
+    language: list[LanguageEnum]
+    toolType: list[ToolTypeEnum]
+    topic: list[TopicItem]
+    function: list[FunctionItem] | None
+    documentation: None = None
+    maturity: None = None
+    publication: None = None
+    link: list[LinkItem]
 
     def __init__(self):
-        # RootModels in the real schema
-        self.biotoolsID = BiotoolsIdType(root="tool-name")
-        self.homepage = UrlftpType(root="https://example.org")
-
-        # Plain fields
-        self.name = "tool-name"
-        self.description = "Existing tool description"
-
-        # License is an enum member (NOT a list)
-        self.license = BioToolsLicense.MIT
-
-        # version is a list of VersionType RootModels (NOT a plain string)
-        self.version = [VersionType(root="1.2.3")]
-
-        # language is a list of LanguageEnum
-        self.language = [LanguageEnum.Python]
-
-        # toolType is a list of ToolTypeEnum (needed by readme mapping)
-        self.toolType = [ToolTypeEnum.Command_line_tool]
-
-        # topic is a list of TopicItem (needed by topics mapping)
-        self.topic = [TopicItem(term="Genomics", uri="http://edamontology.org/topic_0622")]
-
-        # function is a list[FunctionItem] or None.
-        self.function = [
-            FunctionItem(
-                operation=[
-                    OperationItem(
-                        term="Multiple sequence alignment",
-                        uri="http://edamontology.org/operation_0492",
-                    )
-                ],
-            )
-        ]
-
-        # fields used by other pipelines
-        self.documentation = None
-        self.maturity = None
-        self.publication = None
-
-        # link is list of LinkItem in real model
-        self.link = [
-            LinkItem(url=UrlftpType(root="https://tool.com/a"), type=[TypeEnum.Repository]),
-            LinkItem(url=UrlftpType(root="https://tool.com/b"), type=[TypeEnum.Repository]),
-        ]
+        super().__init__(
+            biotoolsID=BiotoolsIdType(root="tool-name"),
+            homepage=UrlftpType(root="https://example.org"),
+            name="tool-name",
+            description="Existing tool description",
+            license=BioToolsLicense.MIT,
+            version=[VersionType(root="1.2.3")],
+            language=[LanguageEnum.Python],
+            toolType=[ToolTypeEnum.Command_line_tool],
+            topic=[TopicItem(term="Genomics", uri="http://edamontology.org/topic_0622")],
+            function=[
+                FunctionItem(
+                    operation=[
+                        OperationItem(
+                            term="Multiple sequence alignment",
+                            uri="http://edamontology.org/operation_0492",
+                        )
+                    ]
+                )
+            ],
+            link=[
+                LinkItem(url=UrlftpType(root="https://tool.com/a"), type=[TypeEnum.Repository]),
+                LinkItem(url=UrlftpType(root="https://tool.com/b"), type=[TypeEnum.Repository]),
+            ],
+        )


### PR DESCRIPTION
## Summary
Include original data in new bio.tools JSON. Basically output original metadata with fields updated by the bridge in gh->bt.

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [x] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #121 