### PR TITLE
Support custom licenses and not licensed gh->bt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ __pycache__/
 # VSCode
 .vscode
 
+# virtual environments
+.venv/
+poetry.toml
+
 # Tests
 .coverage
 htmlcov/

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
@@ -21,8 +21,10 @@ def map_license(gh_license: str | None, bt_license: License | None) -> License |
     Map and reconcile GitHub and bio.tools license annotations using the generic
     GitHub-over-bio.tools policy.
 
-    If GitHub provides a license but it is not recognized as a valid SPDX ID, and there is no existing
+    - If GitHub provides a license but it is not recognized as a valid SPDX ID, and there is no existing
     bio.tools license to fall back on, this function will log a note and return `License.Other`.
+    - If GitHub provides no license and there is no existing bio.tools license, this function will
+    return `License.Not_licensed`.
 
     Parameters
     ----------
@@ -40,8 +42,15 @@ def map_license(gh_license: str | None, bt_license: License | None) -> License |
     """
     if gh_license is None:
         # if no GitHub license, return bio.tools license, which may be None
-        logger.note("GitHub has no license SPDX ID, nothing to map")
-        return bt_license
+        if bt_license is not None:
+            logger.note("GitHub has no license SPDX ID, nothing to map")
+            return bt_license
+
+        logger.added(
+            "GitHub has no license SPDX ID, and no existing bio.tools license to fall back on. "
+            "Setting license to 'Not licensed' in bio.tools metadata.",
+        )
+        return License.Not_licensed
 
     reconciled_license = reconcile_gh_over_bt(
         gh_norm=gh_license,

--- a/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
+++ b/src/bridge/pipelines/gh2bt_for_meta/map_funcs/license.py
@@ -21,6 +21,9 @@ def map_license(gh_license: str | None, bt_license: License | None) -> License |
     Map and reconcile GitHub and bio.tools license annotations using the generic
     GitHub-over-bio.tools policy.
 
+    If GitHub provides a license but it is not recognized as a valid SPDX ID, and there is no existing
+    bio.tools license to fall back on, this function will log a note and return `License.Other`.
+
     Parameters
     ----------
     gh_license : str | None
@@ -40,10 +43,20 @@ def map_license(gh_license: str | None, bt_license: License | None) -> License |
         logger.note("GitHub has no license SPDX ID, nothing to map")
         return bt_license
 
-    return reconcile_gh_over_bt(
+    reconciled_license = reconcile_gh_over_bt(
         gh_norm=gh_license,
         bt_norm=bt_license,
         bt_value=bt_license,
         build_bt_from_gh=lambda gh: find_matching_enum_member(gh, License),
         log_label="license",
     )
+
+    if reconciled_license is None:
+        logger.added(
+            f"GitHub license '{gh_license}' is not recognized as a valid SPDX ID, "
+            "and no existing bio.tools license to fall back on. "
+            "Setting license to 'Other' in bio.tools metadata.",
+        )
+        return License.Other
+
+    return reconciled_license

--- a/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_license.py
+++ b/tests/unit/pipelines/gh2bt_for_meta/map_funcs/test_license.py
@@ -14,7 +14,7 @@ from bridge.pipelines.gh2bt_for_meta.map_funcs.license import map_license
         # Case 1: No GitHub license, bio.tools license exists
         (None, License.MIT, License.MIT),
         # Case 2: No GitHub license, no bio.tools license
-        (None, None, None),
+        (None, None, License.Not_licensed),
         # Case 3: GitHub license exists, no bio.tools license
         ("Apache-2.0", None, License.Apache_2_0),
         # Case 4: Both licenses exist and match
@@ -24,7 +24,7 @@ from bridge.pipelines.gh2bt_for_meta.map_funcs.license import map_license
         # Case 6: GitHub license unrecognized, bio.tools exists → preserve bt
         ("NOT-A-REAL-SPDX", License.MIT, License.MIT),
         # Case 7: GitHub license unrecognized, no bio.tools license
-        ("NOT-A-REAL-SPDX", None, None),
+        ("NOT-A-REAL-SPDX", None, License.Other),
     ],
 )
 def test_map_license(gh_license, bt_license, expected):


### PR DESCRIPTION
## Summary
- If GitHub provides a license but it is not recognized as a valid SPDX ID, and there is no existing
    bio.tools license to fall back on, this function will log a note and return `License.Other`.
- If GitHub provides no license and there is no existing bio.tools license, this function will
    return `License.Not_licensed`.

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] tests
- [ ] hotfix
- [ ] exp

## Checklist
- [x] Rebased on latest `dev`
- [x] Passes all pre-commit hooks (`poetry run fmt` and `poetry run lint`)
- [x] Docs updated if needed
- [x] Tests added/updated if needed
- [x] Linked to an issue if applicable: Closes #127 